### PR TITLE
Allow messages to be sent from SNS topic

### DIFF
--- a/payment-failure/cloud-formation.yaml
+++ b/payment-failure/cloud-formation.yaml
@@ -8,13 +8,9 @@ Parameters:
     AllowedValues:
       - CODE
       - PROD
-
-Mappings:
-  StageMap:
-    CODE:
-      MembershipAppRole: arn:aws:iam::***REMOVED***:role/Workflow-CODE-MembershipAppRole-BR2CJ3AACTNY
-    PROD:
-      MembershipAppRole: arn:aws:iam::***REMOVED***:role/Workflow-MembershipAppRole-Q4O0MAAL9OB9
+  MembershipAppRole:
+    Description: Arn of the membership app role
+    Type: String
 
 Resources:
   PaymentFailureLambdaRole:
@@ -96,7 +92,7 @@ Resources:
           - Effect: Allow
             Action: sqs:SendMessage
             Principal:
-              AWS: !FindInMap [StageMap, !Ref Stage, MembershipAppRole]
+              AWS: !Ref MembershipAppRole
             Resource: !GetAtt PaymentFailureQueue.Arn
 
   PaymentFailureLambdaEventSource:

--- a/payment-failure/cloud-formation.yaml
+++ b/payment-failure/cloud-formation.yaml
@@ -8,8 +8,8 @@ Parameters:
     AllowedValues:
       - CODE
       - PROD
-  MembershipAppRole:
-    Description: Arn of the membership app role
+  IdentityPaymentFailureTopic:
+    Description: Arn of topic that membership workflow publishes payment failure events to
     Type: String
 
 Resources:
@@ -76,7 +76,7 @@ Resources:
   PaymentFailureQueue:
     Type: AWS::SQS::Queue
     Properties:
-      QueueName: !Sub  ${Stage}-payment-failure
+      QueueName: !Sub ${Stage}-payment-failure
       RedrivePolicy:
         deadLetterTargetArn: !GetAtt PaymentFailureDeadLetterQueue.Arn
         maxReceiveCount: 5
@@ -92,8 +92,11 @@ Resources:
           - Effect: Allow
             Action: sqs:SendMessage
             Principal:
-              AWS: !Ref MembershipAppRole
+              AWS: *
             Resource: !GetAtt PaymentFailureQueue.Arn
+            Condition:
+              ArnEquals:
+                aws:SourceArn: !Ref IdentityPaymentFailureTopic
 
   PaymentFailureLambdaEventSource:
     Type: AWS::Lambda::EventSourceMapping

--- a/payment-failure/cloud-formation.yaml
+++ b/payment-failure/cloud-formation.yaml
@@ -86,7 +86,7 @@ Resources:
         maxReceiveCount: 5
 
   PaymentFailureSqsWriteRole:
-    Type: AWS::SQS:QueuePolicy
+    Type: AWS::SQS::QueuePolicy
     Properties:
       Queues: !Ref PaymentFailureQueue
       PolicyDocument:
@@ -95,7 +95,7 @@ Resources:
           - Effect: Allow
             Action: sqs:SendMessage
             Principal:
-              AWS: !FindInMap [StageMap, !Sub ${Stage}, MembershipAppRole]
+              AWS: !FindInMap [StageMap, !Ref Stage, MembershipAppRole]
             Resource: !GetAtt PaymentFailureQueue.Arn
 
   PaymentFailureLambdaEventSource:

--- a/payment-failure/cloud-formation.yaml
+++ b/payment-failure/cloud-formation.yaml
@@ -8,10 +8,13 @@ Parameters:
     AllowedValues:
       - CODE
       - PROD
-  MembershipAccountId:
-    Description: Membership account Id
-    Type: String
-    Default: ***REMOVED***
+
+Mappings:
+  StageMap:
+    CODE:
+      MembershipAppRole: arn:aws:iam::***REMOVED***:role/Workflow-CODE-MembershipAppRole-BR2CJ3AACTNY
+    PROD:
+      MembershipAppRole: arn:aws:iam::***REMOVED***:role/Workflow-MembershipAppRole-Q4O0MAAL9OB9
 
 Resources:
   PaymentFailureLambdaRole:
@@ -83,25 +86,17 @@ Resources:
         maxReceiveCount: 5
 
   PaymentFailureSqsWriteRole:
-    Type: AWS::IAM::Role
+    Type: AWS::SQS:QueuePolicy
     Properties:
-      Path: /
-      AssumeRolePolicyDocument:
+      Queues: !Ref PaymentFailureQueue
+      PolicyDocument:
         Version: 2012-10-17
         Statement:
-        - Effect: Allow
-          Action: sts:AssumeRole
-          Principal:
-            AWS: !Sub arn:aws:iam::${MembershipAccountId}:root
-      Policies:
-      - PolicyName: payment-failure-sqs-write-access-policy
-        PolicyDocument:
-          Version: 2012-10-17
-          Statement:
           - Effect: Allow
+            Action: sqs:SendMessage
+            Principal:
+              AWS: !FindInMap [StageMap, !Sub ${Stage}, MembershipAppRole]
             Resource: !GetAtt PaymentFailureQueue.Arn
-            Action:
-             - sqs:SendMessage
 
   PaymentFailureLambdaEventSource:
     Type: AWS::Lambda::EventSourceMapping

--- a/payment-failure/cloud-formation.yaml
+++ b/payment-failure/cloud-formation.yaml
@@ -92,7 +92,7 @@ Resources:
           - Effect: Allow
             Action: sqs:SendMessage
             Principal:
-              AWS: *
+              AWS: '*'
             Resource: !GetAtt PaymentFailureQueue.Arn
             Condition:
               ArnEquals:

--- a/payment-failure/cloud-formation.yaml
+++ b/payment-failure/cloud-formation.yaml
@@ -88,7 +88,8 @@ Resources:
   PaymentFailureSqsWriteRole:
     Type: AWS::SQS::QueuePolicy
     Properties:
-      Queues: !Ref PaymentFailureQueue
+      Queues:
+      - !Ref PaymentFailureQueue
       PolicyDocument:
         Version: 2012-10-17
         Statement:


### PR DESCRIPTION
After talking to @QuarpT, we have decided to publish payment failure events to an SNS topic in membership, and then send them to the queue in Identity. This is a convenient way of keeping the queue in the identity account, whilst ensuring membership workflow can be run locally with just membership credentials.

Note that [#158](https://github.com/guardian/membership-workflow/pull/158) in membership-workflow must first be merged so that there is a valid topic to reference for the `IdentityPaymentFailureTopic` parameter.