### PR TITLE
Add braze integration and sendEmailTest

### DIFF
--- a/payment-failure/cloud-formation.yaml
+++ b/payment-failure/cloud-formation.yaml
@@ -11,7 +11,18 @@ Parameters:
   IdentityPaymentFailureTopic:
     Description: Arn of topic that membership workflow publishes payment failure events to
     Type: String
+  TopicPagerDutyAlerts:
+    Type: AWS::SNS::Topic
+    Properties:
+      DisplayName: PagerDutyTopic
+      Subscription:
+      - Endpoint: https://events.pagerduty.com/adapter/cloudwatch_sns/v1/96fdc0179acb4c5db3e059d775ea6a9e
+        Protocol: https
 
+Conditions:
+  IsProd: !Equals
+    - !Ref 'Stage'
+    - PROD
 Resources:
   PaymentFailureLambdaRole:
     Type: AWS::IAM::Role
@@ -104,3 +115,29 @@ Resources:
     Properties:
       EventSourceArn: !GetAtt PaymentFailureQueue.Arn
       FunctionName: !GetAtt PaymentFailureLambda.Arn
+
+  PaymentFailureDeadLetterQueueAlert:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmDescription: Alarm if payment failure dead letter queue grows beyond 1
+        message
+      Namespace: AWS/SQS
+      MetricName: ApproximateNumberOfMessagesVisible
+      Dimensions:
+        - Name: QueueName
+          Value: !GetAtt 'PaymentFailureQueue.QueueName'
+      Statistic: Sum
+      Period: '300'
+      EvaluationPeriods: '1'
+      Threshold: '0'
+      ComparisonOperator: GreaterThanThreshold
+      AlarmActions: !If
+        - IsProd
+        - - !Ref 'TopicPagerDutyAlerts'
+        - !Ref 'AWS::NoValue'
+      InsufficientDataActions: !If
+        - IsProd
+        - - !Ref 'AlarmInfoSNS'
+        - !Ref 'AWS::NoValue'
+      OKActions:
+      - !If [IsProd, !Ref 'TopicPagerDutyAlerts', !Ref 'AWS::NoValue']

--- a/payment-failure/cloud-formation.yaml
+++ b/payment-failure/cloud-formation.yaml
@@ -11,6 +11,12 @@ Parameters:
   IdentityPaymentFailureTopic:
     Description: Arn of topic that membership workflow publishes payment failure events to
     Type: String
+
+Conditions:
+  IsProd: !Equals
+    - !Ref 'Stage'
+    - PROD
+Resources:
   TopicPagerDutyAlerts:
     Type: AWS::SNS::Topic
     Properties:
@@ -18,12 +24,6 @@ Parameters:
       Subscription:
       - Endpoint: https://events.pagerduty.com/adapter/cloudwatch_sns/v1/96fdc0179acb4c5db3e059d775ea6a9e
         Protocol: https
-
-Conditions:
-  IsProd: !Equals
-    - !Ref 'Stage'
-    - PROD
-Resources:
   PaymentFailureLambdaRole:
     Type: AWS::IAM::Role
     Properties:
@@ -125,19 +125,54 @@ Resources:
       MetricName: ApproximateNumberOfMessagesVisible
       Dimensions:
         - Name: QueueName
-          Value: !GetAtt 'PaymentFailureQueue.QueueName'
+          Value: !GetAtt 'PaymentFailureDeadLetterQueue.QueueName'
       Statistic: Sum
       Period: '300'
       EvaluationPeriods: '1'
       Threshold: '0'
       ComparisonOperator: GreaterThanThreshold
-      AlarmActions: !If
-        - IsProd
-        - - !Ref 'TopicPagerDutyAlerts'
-        - !Ref 'AWS::NoValue'
-      InsufficientDataActions: !If
-        - IsProd
-        - - !Ref 'AlarmInfoSNS'
-        - !Ref 'AWS::NoValue'
+      AlarmActions:
+      - !If [IsProd, !Ref 'TopicPagerDutyAlerts', !Ref 'AWS::NoValue']
+      InsufficientDataActions:
+      - !If [IsProd, !Ref 'TopicPagerDutyAlerts', !Ref 'AWS::NoValue']
       OKActions:
+      - !If [IsProd, !Ref 'TopicPagerDutyAlerts', !Ref 'AWS::NoValue']
+
+  PaymentFailureQueueLengthAlert:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmDescription: Alarm if payment failure queue grows beyond 300
+        message
+      Namespace: AWS/SQS
+      MetricName: ApproximateNumberOfMessagesVisible
+      Dimensions:
+        - Name: QueueName
+          Value: !GetAtt 'PaymentFailureQueue.QueueName'
+      Statistic: Sum
+      Period: '60'
+      EvaluationPeriods: '10'
+      Threshold: '300'
+      ComparisonOperator: GreaterThanThreshold
+      AlarmActions:
+      - !If [IsProd, !Ref 'TopicPagerDutyAlerts', !Ref 'AWS::NoValue']
+      InsufficientDataActions:
+      - !If [IsProd, !Ref 'TopicPagerDutyAlerts', !Ref 'AWS::NoValue']
+      OKActions:
+      - !If [IsProd, !Ref 'TopicPagerDutyAlerts', !Ref 'AWS::NoValue']
+
+  PaymentFailureLambdaErrorAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmDescription: Alert when payment failure lambda errors
+      Namespace: AWS/Lambda
+      Dimensions:
+        - Name: FunctionName
+          Value: !Ref 'PaymentFailureLambda'
+      MetricName: Errors
+      Statistic: Sum
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Threshold: '1'
+      Period: '60'
+      EvaluationPeriods: '1'
+      AlarmActions:
       - !If [IsProd, !Ref 'TopicPagerDutyAlerts', !Ref 'AWS::NoValue']

--- a/payment-failure/src/main/scala/com/gu/identity/paymentfailure/BrazeClient.scala
+++ b/payment-failure/src/main/scala/com/gu/identity/paymentfailure/BrazeClient.scala
@@ -5,9 +5,9 @@ import scalaj.http.Http
 import io.circe.syntax._
 
 
-class BrazeClient extends StrictLogging{
+class BrazeClient(config: Config) extends StrictLogging {
 
-  def sendEmail(emailData: IdentityBrazeEmailData, emailToken: String, config: Config) : Either[Throwable, BrazeResponse] = {
+  def sendEmail(emailData: IdentityBrazeEmailData, emailToken: String) : Either[Throwable, BrazeResponse] = {
 
     logger.info(s"send BrazeEmail for email ${emailData.emailAddress} with token $emailToken with templateId ${emailData.templateId}")
 

--- a/payment-failure/src/main/scala/com/gu/identity/paymentfailure/BrazeClient.scala
+++ b/payment-failure/src/main/scala/com/gu/identity/paymentfailure/BrazeClient.scala
@@ -8,6 +8,7 @@ import io.circe.syntax._
 class BrazeClient extends StrictLogging{
 
   def sendEmail(emailData: IdentityBrazeEmailData, emailToken: String, config: Config) : Either[Throwable, BrazeResponse] = {
+    
     logger.info(s"send BrazeEmail for email ${emailData.emailAddress} with token $emailToken with templateId ${emailData.templateId}")
 
     val sendRequest = BrazeSendRequest(emailData.externalId, config.brazeApiKey, emailData.templateId, emailData.customFields + ("emailToken" -> emailToken))

--- a/payment-failure/src/main/scala/com/gu/identity/paymentfailure/BrazeClient.scala
+++ b/payment-failure/src/main/scala/com/gu/identity/paymentfailure/BrazeClient.scala
@@ -8,7 +8,7 @@ import io.circe.syntax._
 class BrazeClient extends StrictLogging{
 
   def sendEmail(emailData: IdentityBrazeEmailData, emailToken: String, config: Config) : Either[Throwable, BrazeResponse] = {
-    
+
     logger.info(s"send BrazeEmail for email ${emailData.emailAddress} with token $emailToken with templateId ${emailData.templateId}")
 
     val sendRequest = BrazeSendRequest(emailData.externalId, config.brazeApiKey, emailData.templateId, emailData.customFields + ("emailToken" -> emailToken))
@@ -22,7 +22,7 @@ class BrazeClient extends StrictLogging{
       logger.info(s"Successfully sent email from Braze for email: ${emailData.emailAddress} with templateId ${emailData.templateId}")
       io.circe.parser.decode[BrazeResponse](postResponse.body)
     } else {
-      logger.info(s"Failed to send email from Braze, error with status ${postResponse.code} - error ${postResponse.body}")
+      logger.error(s"Failed to send email from Braze, error with status ${postResponse.code} - error ${postResponse.body}")
       Left( new Exception(s"sendEmail error with status ${postResponse.code} - error ${postResponse.body}"))
     }
   }

--- a/payment-failure/src/main/scala/com/gu/identity/paymentfailure/BrazeClient.scala
+++ b/payment-failure/src/main/scala/com/gu/identity/paymentfailure/BrazeClient.scala
@@ -1,15 +1,28 @@
 package com.gu.identity.paymentfailure
 
 import com.typesafe.scalalogging.StrictLogging
+import scalaj.http.Http
+import io.circe.syntax._
+
 
 class BrazeClient extends StrictLogging{
 
-  def sendEmail(emailData: IdentityBrazeEmailData, emailToken: String) : Either[Throwable, BrazeResponse] = {
-    val isSuccess = true
-    logger.info(s"Sending payment failure request to braze for email ${emailData.emailAddress} with token $emailToken")
-    isSuccess match {
-      case true => Right(BrazeResponse("example success response"))
-      case false => Left(new Exception( s"Failed to send email from Braze"))
+  def sendEmail(emailData: IdentityBrazeEmailData, emailToken: String, config: Config) : Either[Throwable, BrazeResponse] = {
+    logger.info(s"send BrazeEmail for email ${emailData.emailAddress} with token $emailToken with templateId ${emailData.templateId}")
+
+    val sendRequest = BrazeSendRequest(emailData.externalId, config.brazeApiKey, emailData.templateId, emailData.customFields + ("emailToken" -> emailToken))
+
+    val postResponse = Http(s"${config.brazeApiHost}/campaigns/trigger/send")
+        .header("content-type", "application/json")
+        .postData(sendRequest.asJson.toString)
+        .asString
+
+    if (postResponse.isSuccess) {
+      logger.info(s"Successfully sent email from Braze for email: ${emailData.emailAddress} with templateId ${emailData.templateId}")
+      io.circe.parser.decode[BrazeUnitResponse](postResponse.body)
+    } else {
+      logger.info(s"Failed to send email from Braze, error with status ${postResponse.code} - error ${postResponse.body}")
+      Left( new Exception(s"sendEmail error with status ${postResponse.code} - error ${postResponse.body}"))
     }
   }
 }

--- a/payment-failure/src/main/scala/com/gu/identity/paymentfailure/BrazeClient.scala
+++ b/payment-failure/src/main/scala/com/gu/identity/paymentfailure/BrazeClient.scala
@@ -19,7 +19,7 @@ class BrazeClient extends StrictLogging{
 
     if (postResponse.isSuccess) {
       logger.info(s"Successfully sent email from Braze for email: ${emailData.emailAddress} with templateId ${emailData.templateId}")
-      io.circe.parser.decode[BrazeUnitResponse](postResponse.body)
+      io.circe.parser.decode[BrazeResponse](postResponse.body)
     } else {
       logger.info(s"Failed to send email from Braze, error with status ${postResponse.code} - error ${postResponse.body}")
       Left( new Exception(s"sendEmail error with status ${postResponse.code} - error ${postResponse.body}"))

--- a/payment-failure/src/main/scala/com/gu/identity/paymentfailure/IdentityClient.scala
+++ b/payment-failure/src/main/scala/com/gu/identity/paymentfailure/IdentityClient.scala
@@ -22,7 +22,7 @@ object IdentityEmailTokenResponse {
 
 class IdentityClient(config: Config) extends StrictLogging {
 
-  def encryptEmail(email: String, config:Config): Either[Throwable, IdentityEmailTokenResponse] = {
+  def encryptEmail(email: String): Either[Throwable, IdentityEmailTokenResponse] = {
     logger.info(s"retrieving encrypted token for email : $email")
 
     val postResponse = Http(s"${config.idapiHost}/signin-token/email")

--- a/payment-failure/src/main/scala/com/gu/identity/paymentfailure/Lambda.scala
+++ b/payment-failure/src/main/scala/com/gu/identity/paymentfailure/Lambda.scala
@@ -30,8 +30,8 @@ object Lambda extends StrictLogging {
   val config =  getConfig.valueOr(throw _)
   val identityClient = new IdentityClient(config)
   val sqsService = new SqsService(config)
-  val brazeClient = new BrazeClient
-  val sendEmailService = new SendEmailService(identityClient, brazeClient)
+  val brazeClient = new BrazeClient(config)
+  val sendEmailService = new SendEmailService(identityClient, brazeClient, config)
 
   def handler(event: SQSEvent, context: Context): Unit = {
 
@@ -51,7 +51,7 @@ object Lambda extends StrictLogging {
     messages.map( mes => {
       for {
         emailData <- sqsService.parseSingleMessage(mes)
-        brazeResponse <- sendEmailService.sendEmail(emailData, config)
+        brazeResponse <- sendEmailService.sendEmail(emailData)
         result <- sqsService.deleteMessage(mes)
         _ <- sqsService.processDeleteMessageResult(result)
       } yield brazeResponse

--- a/payment-failure/src/main/scala/com/gu/identity/paymentfailure/Lambda.scala
+++ b/payment-failure/src/main/scala/com/gu/identity/paymentfailure/Lambda.scala
@@ -21,8 +21,9 @@ object Lambda extends StrictLogging {
       brazeApiHost <- getEnvironmentVariable("brazeApiHost")
       idapiAccessToken <- getEnvironmentVariable("idapiAccessToken")
       sqsQueueUrl <- getEnvironmentVariable("sqsQueueUrl")
+      brazeApiKey <- getEnvironmentVariable("brazeApiKey")
     } yield {
-      Config(idapiHost, brazeApiHost, idapiAccessToken, sqsQueueUrl)
+      Config(idapiHost, brazeApiHost, idapiAccessToken, sqsQueueUrl, brazeApiKey)
     }
   }
 

--- a/payment-failure/src/main/scala/com/gu/identity/paymentfailure/Model.scala
+++ b/payment-failure/src/main/scala/com/gu/identity/paymentfailure/Model.scala
@@ -3,7 +3,7 @@ package com.gu.identity.paymentfailure
 import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
 import io.circe.{Decoder, Encoder}
 
-case class Config(idapiHost: String, brazeApiHost: String, idapiAccessToken: String, queueURL: String, brazeApiKey:String)
+case class Config(idapiHost: String, brazeApiHost: String, idapiAccessToken: String, queueURL: String, brazeApiKey: String)
 
 case class IdentityBrazeEmailData(externalId: String, emailAddress: String, templateId: String, customFields: Map[String, String])
 

--- a/payment-failure/src/main/scala/com/gu/identity/paymentfailure/Model.scala
+++ b/payment-failure/src/main/scala/com/gu/identity/paymentfailure/Model.scala
@@ -29,14 +29,8 @@ object BrazeSendRequest {
   }
 }
 
-sealed trait BrazeResponse {
-  def message: String
-  // queued is only returned when Braze is performing maintenance
-  def isSuccess: Boolean = message == "success" || message == "queued"
-}
+case class BrazeResponse(message: String)
 
-case class BrazeUnitResponse(message: String) extends BrazeResponse
-
-object BrazeUnitResponse {
-  implicit val BrazeUnitResponseDecoder: Decoder[BrazeUnitResponse] = deriveDecoder[BrazeUnitResponse]
+object BrazeResponse {
+  implicit val BrazeUnitResponseDecoder: Decoder[BrazeResponse] = deriveDecoder[BrazeResponse]
 }

--- a/payment-failure/src/main/scala/com/gu/identity/paymentfailure/Model.scala
+++ b/payment-failure/src/main/scala/com/gu/identity/paymentfailure/Model.scala
@@ -1,7 +1,9 @@
 package com.gu.identity.paymentfailure
 
-import io.circe.generic.semiauto.deriveDecoder
-import io.circe.Decoder
+import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
+import io.circe.{Decoder, Encoder}
+
+case class Config(idapiHost: String, brazeApiHost: String, idapiAccessToken: String, queueURL: String, brazeApiKey:String)
 
 case class IdentityBrazeEmailData(externalId: String, emailAddress: String, templateId: String, customFields: Map[String, String])
 
@@ -9,7 +11,32 @@ object IdentityBrazeEmailData {
   implicit val identityBrazeEmailDataDecoder: Decoder[IdentityBrazeEmailData] = deriveDecoder[IdentityBrazeEmailData]
 }
 
-case class BrazeResponse(msg: String)
+case class BrazeRecipient(external_user_id: String, trigger_properties: Option[Map[String, String]])
 
-case class Config(idapiHost: String, brazeApiHost: String, idapiAccessToken: String, queueURL: String)
+object BrazeRecipient {
+  implicit val brazeRecipientEncoder: Encoder[BrazeRecipient] = deriveEncoder[BrazeRecipient]
+}
 
+case class BrazeSendRequest(api_key: String,
+                            campaign_id: String,
+                            trigger_properties: Option[Map[String, String]],
+                            recipients: Seq[BrazeRecipient])
+
+object BrazeSendRequest {
+  implicit val BrazeSendRequestEncoder: Encoder[BrazeSendRequest] = deriveEncoder[BrazeSendRequest]
+  def apply(userId: String, apiKey: String, campaignId: String, customProperties: Map[String, String]): BrazeSendRequest = {
+    BrazeSendRequest(apiKey, campaignId, None, List(BrazeRecipient(userId, Some(customProperties))))
+  }
+}
+
+sealed trait BrazeResponse {
+  def message: String
+  // queued is only returned when Braze is performing maintenance
+  def isSuccess: Boolean = message == "success" || message == "queued"
+}
+
+case class BrazeUnitResponse(message: String) extends BrazeResponse
+
+object BrazeUnitResponse {
+  implicit val BrazeUnitResponseDecoder: Decoder[BrazeUnitResponse] = deriveDecoder[BrazeUnitResponse]
+}

--- a/payment-failure/src/main/scala/com/gu/identity/paymentfailure/Model.scala
+++ b/payment-failure/src/main/scala/com/gu/identity/paymentfailure/Model.scala
@@ -11,22 +11,16 @@ object IdentityBrazeEmailData {
   implicit val identityBrazeEmailDataDecoder: Decoder[IdentityBrazeEmailData] = deriveDecoder[IdentityBrazeEmailData]
 }
 
-case class BrazeRecipient(external_user_id: String, trigger_properties: Option[Map[String, String]])
+case class BrazeRecipient(external_user_id: String, trigger_properties: Map[String, String])
 
 object BrazeRecipient {
   implicit val brazeRecipientEncoder: Encoder[BrazeRecipient] = deriveEncoder[BrazeRecipient]
 }
 
-case class BrazeSendRequest(api_key: String,
-                            campaign_id: String,
-                            trigger_properties: Option[Map[String, String]],
-                            recipients: Seq[BrazeRecipient])
+case class BrazeSendRequest(api_key: String, campaign_id: String, recipients: Seq[BrazeRecipient])
 
 object BrazeSendRequest {
   implicit val BrazeSendRequestEncoder: Encoder[BrazeSendRequest] = deriveEncoder[BrazeSendRequest]
-  def apply(userId: String, apiKey: String, campaignId: String, customProperties: Map[String, String]): BrazeSendRequest = {
-    BrazeSendRequest(apiKey, campaignId, None, List(BrazeRecipient(userId, Some(customProperties))))
-  }
 }
 
 case class BrazeResponse(message: String)

--- a/payment-failure/src/main/scala/com/gu/identity/paymentfailure/SendEmailService.scala
+++ b/payment-failure/src/main/scala/com/gu/identity/paymentfailure/SendEmailService.scala
@@ -1,11 +1,11 @@
 package com.gu.identity.paymentfailure
 
-class SendEmailService (identityClient: IdentityClient, brazeClient: BrazeClient){
+class SendEmailService (identityClient: IdentityClient, brazeClient: BrazeClient, config: Config){
 
-  def sendEmail(emailData: IdentityBrazeEmailData, config: Config): Either[Throwable, BrazeResponse] = {
+  def sendEmail(emailData: IdentityBrazeEmailData): Either[Throwable, BrazeResponse] = {
     for {
-      encryptedTokenResponse <- identityClient.encryptEmail(emailData.emailAddress, config)
-      brazeResponse <- brazeClient.sendEmail(emailData, encryptedTokenResponse.encryptedEmail, config)
+      encryptedTokenResponse <- identityClient.encryptEmail(emailData.emailAddress)
+      brazeResponse <- brazeClient.sendEmail(emailData, encryptedTokenResponse.encryptedEmail)
     } yield brazeResponse
   }
 }

--- a/payment-failure/src/main/scala/com/gu/identity/paymentfailure/SendEmailService.scala
+++ b/payment-failure/src/main/scala/com/gu/identity/paymentfailure/SendEmailService.scala
@@ -5,7 +5,7 @@ class SendEmailService (identityClient: IdentityClient, brazeClient: BrazeClient
   def sendEmail(emailData: IdentityBrazeEmailData, config: Config): Either[Throwable, BrazeResponse] = {
     for {
       encryptedTokenResponse <- identityClient.encryptEmail(emailData.emailAddress, config)
-      brazeResponse <- brazeClient.sendEmail(emailData, encryptedTokenResponse.encryptedEmail)
+      brazeResponse <- brazeClient.sendEmail(emailData, encryptedTokenResponse.encryptedEmail, config)
     } yield brazeResponse
   }
 }

--- a/payment-failure/src/test/scala/com/gu/identity/paymentfailure/sendEmailService/SendEmailServiceTest.scala
+++ b/payment-failure/src/test/scala/com/gu/identity/paymentfailure/sendEmailService/SendEmailServiceTest.scala
@@ -1,0 +1,43 @@
+package com.gu.identity.paymentfailure.sendEmailService
+
+import com.gu.identity.paymentfailure._
+import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.mockito.MockitoSugar
+import org.mockito.Mockito._
+
+class SendEmailServiceTest extends WordSpec with Matchers with MockitoSugar {
+
+  trait TestFixture {
+    val config = mock[Config]
+    val identityClient = mock[IdentityClient]
+    val brazeClient = mock[BrazeClient]
+    val sendEmailService = new SendEmailService(identityClient, brazeClient)
+  }
+
+  "The sendEmail method" should {
+    "encrypt an email then trigger an email in Braze" in new TestFixture {
+
+      val emailData = IdentityBrazeEmailData("1111", "test@test.com", "templateIdMock", Map("first name" -> "test name"))
+
+      when(identityClient.encryptEmail("test@test.com", config)).thenReturn(Right(IdentityEmailTokenResponse("OK", "encryptedEmailString")))
+      when(brazeClient.sendEmail(emailData, "encryptedEmailString", config)).thenReturn(Right(BrazeUnitResponse("success")))
+      sendEmailService.sendEmail(emailData, config)
+
+      verify(identityClient, times(1)).encryptEmail("test@test.com", config)
+      verify(brazeClient, times(1)).sendEmail(emailData, "encryptedEmailString", config)
+    }
+
+    "not trigger a braze email if email encryption fails" in new TestFixture {
+      val emailData = IdentityBrazeEmailData("1111", "test@test.com", "templateIdMock", Map("first name" -> "test name"))
+
+      val mockException = mock[Exception]
+      when(identityClient.encryptEmail("test@test.com", config)).thenReturn(Left(mockException))
+
+      sendEmailService.sendEmail(emailData, config)
+
+      verify(identityClient, times(1)).encryptEmail("test@test.com", config)
+      verify(brazeClient, never()).sendEmail(emailData, "encryptedEmailString", config)
+
+    }
+  }
+}

--- a/payment-failure/src/test/scala/com/gu/identity/paymentfailure/sendEmailService/SendEmailServiceTest.scala
+++ b/payment-failure/src/test/scala/com/gu/identity/paymentfailure/sendEmailService/SendEmailServiceTest.scala
@@ -20,7 +20,7 @@ class SendEmailServiceTest extends WordSpec with Matchers with MockitoSugar {
       val emailData = IdentityBrazeEmailData("1111", "test@test.com", "templateIdMock", Map("first name" -> "test name"))
 
       when(identityClient.encryptEmail("test@test.com", config)).thenReturn(Right(IdentityEmailTokenResponse("OK", "encryptedEmailString")))
-      when(brazeClient.sendEmail(emailData, "encryptedEmailString", config)).thenReturn(Right(BrazeUnitResponse("success")))
+      when(brazeClient.sendEmail(emailData, "encryptedEmailString", config)).thenReturn(Right(BrazeResponse("success")))
       sendEmailService.sendEmail(emailData, config)
 
       verify(identityClient, times(1)).encryptEmail("test@test.com", config)

--- a/payment-failure/src/test/scala/com/gu/identity/paymentfailure/sendEmailService/SendEmailServiceTest.scala
+++ b/payment-failure/src/test/scala/com/gu/identity/paymentfailure/sendEmailService/SendEmailServiceTest.scala
@@ -11,7 +11,7 @@ class SendEmailServiceTest extends WordSpec with Matchers with MockitoSugar {
     val config = mock[Config]
     val identityClient = mock[IdentityClient]
     val brazeClient = mock[BrazeClient]
-    val sendEmailService = new SendEmailService(identityClient, brazeClient)
+    val sendEmailService = new SendEmailService(identityClient, brazeClient, config)
   }
 
   "The sendEmail method" should {
@@ -19,24 +19,24 @@ class SendEmailServiceTest extends WordSpec with Matchers with MockitoSugar {
 
       val emailData = IdentityBrazeEmailData("1111", "test@test.com", "templateIdMock", Map("first name" -> "test name"))
 
-      when(identityClient.encryptEmail("test@test.com", config)).thenReturn(Right(IdentityEmailTokenResponse("OK", "encryptedEmailString")))
-      when(brazeClient.sendEmail(emailData, "encryptedEmailString", config)).thenReturn(Right(BrazeResponse("success")))
-      sendEmailService.sendEmail(emailData, config)
+      when(identityClient.encryptEmail("test@test.com")).thenReturn(Right(IdentityEmailTokenResponse("OK", "encryptedEmailString")))
+      when(brazeClient.sendEmail(emailData, "encryptedEmailString")).thenReturn(Right(BrazeResponse("success")))
+      sendEmailService.sendEmail(emailData)
 
-      verify(identityClient, times(1)).encryptEmail("test@test.com", config)
-      verify(brazeClient, times(1)).sendEmail(emailData, "encryptedEmailString", config)
+      verify(identityClient, times(1)).encryptEmail("test@test.com")
+      verify(brazeClient, times(1)).sendEmail(emailData, "encryptedEmailString")
     }
 
     "not trigger a braze email if email encryption fails" in new TestFixture {
       val emailData = IdentityBrazeEmailData("1111", "test@test.com", "templateIdMock", Map("first name" -> "test name"))
 
       val mockException = mock[Exception]
-      when(identityClient.encryptEmail("test@test.com", config)).thenReturn(Left(mockException))
+      when(identityClient.encryptEmail("test@test.com")).thenReturn(Left(mockException))
 
-      sendEmailService.sendEmail(emailData, config)
+      sendEmailService.sendEmail(emailData)
 
-      verify(identityClient, times(1)).encryptEmail("test@test.com", config)
-      verify(brazeClient, never()).sendEmail(emailData, "encryptedEmailString", config)
+      verify(identityClient, times(1)).encryptEmail("test@test.com")
+      verify(brazeClient, never()).sendEmail(emailData, "encryptedEmailString")
 
     }
   }


### PR DESCRIPTION
Payment failure lambda should send the request to Braze to send a payment failure email.

I have tested this end to end, so theoretically we can switch over workflow to sending payment failure messages to our queue and there would be no noticable change to the end user.