### PR TITLE
Remove insufficient data alarms on queues

### DIFF
--- a/payment-failure/cloud-formation.yaml
+++ b/payment-failure/cloud-formation.yaml
@@ -133,8 +133,6 @@ Resources:
       ComparisonOperator: GreaterThanThreshold
       AlarmActions:
       - !If [IsProd, !Ref 'TopicPagerDutyAlerts', !Ref 'AWS::NoValue']
-      InsufficientDataActions:
-      - !If [IsProd, !Ref 'TopicPagerDutyAlerts', !Ref 'AWS::NoValue']
       OKActions:
       - !If [IsProd, !Ref 'TopicPagerDutyAlerts', !Ref 'AWS::NoValue']
 
@@ -154,8 +152,6 @@ Resources:
       Threshold: '300'
       ComparisonOperator: GreaterThanThreshold
       AlarmActions:
-      - !If [IsProd, !Ref 'TopicPagerDutyAlerts', !Ref 'AWS::NoValue']
-      InsufficientDataActions:
       - !If [IsProd, !Ref 'TopicPagerDutyAlerts', !Ref 'AWS::NoValue']
       OKActions:
       - !If [IsProd, !Ref 'TopicPagerDutyAlerts', !Ref 'AWS::NoValue']


### PR DESCRIPTION
We don't need insufficient data alarms on the dead letter queues. 