### PR TITLE
Lambda tweaks

### DIFF
--- a/payment-failure/build.sbt
+++ b/payment-failure/build.sbt
@@ -6,18 +6,19 @@ scalaVersion := "2.12.6"
 val circeVersion = "0.10.1"
 
 libraryDependencies ++= Seq(
-  "com.typesafe.scala-logging" %% "scala-logging" % "3.9.0",
-  "org.slf4j" % "slf4j-simple" % "1.7.25",
+  "ch.qos.logback" % "logback-classic" % "1.2.3",
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.0",
   "com.amazonaws" % "aws-lambda-java-events" % "2.2.2",
   "com.amazonaws" % "aws-java-sdk-sqs" % "1.11.472",
+  "com.typesafe.scala-logging" %% "scala-logging" % "3.9.0",
   "io.circe" %% "circe-core" % circeVersion,
   "io.circe" %% "circe-parser" % circeVersion,
   "io.circe" %% "circe-generic" % circeVersion,
+  "org.jlib" % "jlib-awslambda-logback" % "1.0.0",
+  "org.mockito" % "mockito-all" % "1.10.19" % "test",
   "org.scalaj" %% "scalaj-http" % "2.3.0",
   "org.scalactic" %% "scalactic" % "3.0.5",
-  "org.scalatest" %% "scalatest" % "3.0.5" % "test",
-  "org.mockito" % "mockito-all" % "1.10.19" % "test"
+  "org.scalatest" %% "scalatest" % "3.0.5" % "test"
 )
 
 assemblyJarName := "main.jar"

--- a/payment-failure/build.sbt
+++ b/payment-failure/build.sbt
@@ -13,6 +13,8 @@ libraryDependencies ++= Seq(
   "io.circe" %% "circe-core" % circeVersion,
   "io.circe" %% "circe-parser" % circeVersion,
   "io.circe" %% "circe-generic" % circeVersion,
+  // This provides a logback appender which can be used to ensure that multi-line log messages
+  // are considered as single log events in cloudwatch. The logback.xml defines a root logger using this appender.
   "org.jlib" % "jlib-awslambda-logback" % "1.0.0",
   "org.mockito" % "mockito-all" % "1.10.19" % "test",
   "org.scalaj" %% "scalaj-http" % "2.3.0",
@@ -30,7 +32,7 @@ assemblyJarName := "main.jar"
 // https://stackoverflow.com/questions/25144484/sbt-assembly-deduplication-found-error
 assemblyMergeStrategy in assembly := {
   case PathList("module-info.class") => MergeStrategy.discard
-  case x => 
+  case x =>
     val oldStrategy = (assemblyMergeStrategy in assembly).value
     oldStrategy(x)
 }

--- a/payment-failure/build.sbt
+++ b/payment-failure/build.sbt
@@ -6,7 +6,6 @@ scalaVersion := "2.12.6"
 val circeVersion = "0.10.1"
 
 libraryDependencies ++= Seq(
-  "ch.qos.logback" % "logback-classic" % "1.2.3",
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.0",
   "com.amazonaws" % "aws-lambda-java-events" % "2.2.2",
   "com.amazonaws" % "aws-java-sdk-sqs" % "1.11.472",
@@ -22,6 +21,19 @@ libraryDependencies ++= Seq(
 )
 
 assemblyJarName := "main.jar"
+
+// Fixes the clashes caused by:
+// - ch.qos.logback/logback-classic/jars/logback-classic-1.3.0-alpha4.jar:module-info.class
+// - ch.qos.logback/logback-core/jars/logback-core-1.3.0-alpha4.jar:module-info.class
+// - org.slf4j/slf4j-api/jars/slf4j-api-1.8.0-beta1.jar:module-info.class
+// Uses the advice in the stack overflow answer by Elesion Olalekan Fuad and the comment by note:
+// https://stackoverflow.com/questions/25144484/sbt-assembly-deduplication-found-error
+assemblyMergeStrategy in assembly := {
+  case PathList("module-info.class") => MergeStrategy.discard
+  case x => 
+    val oldStrategy = (assemblyMergeStrategy in assembly).value
+    oldStrategy(x)
+}
 
 enablePlugins(RiffRaffArtifact)
 riffRaffPackageType := assembly.value

--- a/payment-failure/cloud-formation.yaml
+++ b/payment-failure/cloud-formation.yaml
@@ -11,6 +11,25 @@ Parameters:
   IdentityPaymentFailureTopic:
     Description: Arn of topic that membership workflow publishes payment failure events to
     Type: String
+  IdentityApiEndpoint:
+    Description: endpoint for the identity API
+    Type: String
+    AllowedValues:
+      - https://idapi.theguardian.com
+      - https://idapi.code.dev-theguardian.com
+  IdentityAPIKey:
+    Description: key used to authenticate against the identity API
+    Type: String
+  BrazeAPIEndpoint:
+    Description: endpoint for the Braze API
+    Type: String
+    Default: https://rest.fra-01.braze.eu
+  BrazeAPIKey:
+    Description: key used to authenticate against the Braze API
+    Type: String
+  SQSQueueUrl:
+    Description: url of the queue that contains payment failure messages
+    Type: String
 
 Conditions:
   IsProd: !Equals
@@ -72,7 +91,11 @@ Resources:
       Description: Lambda to send emails to customers with a recurring payment plan whos card is about to expire or failed
       Environment:
         Variables:
-          Stage: !Sub ${Stage}
+          idapiHost: !Sub ${IdentityApiEndpoint}
+          idapiAccessToken: !Sub ${IdentityAPIKey}
+          brazeApiHost: !Sub ${BrazeAPIEndpoint}
+          brazeApiKey: !Sub ${BrazeAPIKey}
+          sqsQueueUrl: !Sub ${SQSQueueUrl}
       FunctionName: !Sub PaymentFailureLambda-${Stage}
       Handler: com.gu.identity.paymentfailure.Lambda::handler
       Role: !GetAtt PaymentFailureLambdaRole.Arn

--- a/payment-failure/project/plugins.sbt
+++ b/payment-failure/project/plugins.sbt
@@ -1,1 +1,3 @@
 addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.0.0")
+
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.2")

--- a/payment-failure/src/main/resources/logback.xml
+++ b/payment-failure/src/main/resources/logback.xml
@@ -1,0 +1,13 @@
+<configuration>
+
+    <appender name="awslambda" class="org.jlib.cloud.aws.lambda.logback.AwsLambdaAppender">
+        <encoder type="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>[%d{yyyy-MM-dd HH:mm:ss.SSS}] &lt;%-36X{AWSRequestId:-request-id-not-set-by-lambda-runtime}&gt; %-5level %logger{10} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="awslambda" />
+    </root>
+
+</configuration>

--- a/payment-failure/src/main/scala/com/gu/identity/paymentfailure/Lambda.scala
+++ b/payment-failure/src/main/scala/com/gu/identity/paymentfailure/Lambda.scala
@@ -7,12 +7,11 @@ import cats.syntax.either._
 
 object Lambda extends StrictLogging {
 
-  def getEnvironmentVariable(env: String): Either[Throwable, String] = {
-    Option(System.getenv(env)) match {
-      case Some(variable) => Right(variable)
-      case _ => Left(new Exception(s"Missing or incorrect config. Please check environment variables"))
-    }
-  }
+  def getEnvironmentVariable(env: String): Either[Throwable, String] =
+    Either.fromOption(
+      Option(System.getenv(env)),
+      new Exception(s"environment variable $env not defined")
+    )
 
   def getConfig: Either[Throwable, Config] = {
     for {

--- a/payment-failure/src/main/scala/com/gu/identity/paymentfailure/Lambda.scala
+++ b/payment-failure/src/main/scala/com/gu/identity/paymentfailure/Lambda.scala
@@ -27,18 +27,20 @@ object Lambda extends StrictLogging {
     }
   }
 
-  val config =  getConfig.valueOr(throw _)
-  val identityClient = new IdentityClient(config)
-  val sqsService = new SqsService(config)
-  val brazeClient = new BrazeClient(config)
-  val sendEmailService = new SendEmailService(identityClient, brazeClient, config)
-
   def handler(event: SQSEvent, context: Context): Unit = {
 
     logger.info(s"context :  $context")
     logger.info(s"event :  $event")
     logger.info(s"received message batch of size: ${event.getRecords.size}")
 
+    logger.info("initialising config and services")
+    val config =  getConfig.valueOr(throw _)
+    val identityClient = new IdentityClient(config)
+    val sqsService = new SqsService(config)
+    val brazeClient = new BrazeClient(config)
+    val sendEmailService = new SendEmailService(identityClient, brazeClient, config)
+
+    logger.info("config and services successfully initialised - processing events")
     process(event).foreach {
       case Left(throwable) => throw throwable
       case _ => logger.info("process successful")

--- a/payment-failure/src/main/scala/com/gu/identity/paymentfailure/LambdaService.scala
+++ b/payment-failure/src/main/scala/com/gu/identity/paymentfailure/LambdaService.scala
@@ -1,0 +1,30 @@
+package com.gu.identity.paymentfailure
+
+import com.amazonaws.services.lambda.runtime.events.SQSEvent
+
+import scala.collection.JavaConverters._
+
+class LambdaService private (sqsService: SqsService, sendEmailService: SendEmailService) {
+
+  def processEvent(event: SQSEvent): List[Either[Throwable, BrazeResponse]] =
+    event.getRecords.asScala.toList.map { message =>
+      for {
+        emailData <- sqsService.parseSingleMessage(message)
+        brazeResponse <- sendEmailService.sendEmail(emailData)
+        result <- sqsService.deleteMessage(message)
+        _ <- sqsService.processDeleteMessageResult(result)
+      } yield brazeResponse
+    }
+}
+
+object LambdaService {
+
+  def fromConfig(config: Config): LambdaService = {
+    val identityClient = new IdentityClient(config)
+    val sqsService = new SqsService(config)
+    val brazeClient = new BrazeClient(config)
+    val sendEmailService = new SendEmailService(identityClient, brazeClient, config)
+    new LambdaService(sqsService, sendEmailService)
+  }
+}
+


### PR DESCRIPTION
This PR resolves a couple of issues with the current lambda:
- stops environment variables from being wiped on each deploy by defining them in cloud formation (good spot @Calum-Campbell)
- uses logback and a custom appender (from jlib-awslambda-logback) to ensure that multi-line log entries are still just one event in logback
- derives the config and initialise the services from within the `Lambda::handler()` function (to try and provide more meaningful log messages if the environment variables required by the configuration are missing)