### PR TITLE
Minor logging improvements

### DIFF
--- a/payment-failure/src/main/scala/com/gu/identity/paymentfailure/BrazeClient.scala
+++ b/payment-failure/src/main/scala/com/gu/identity/paymentfailure/BrazeClient.scala
@@ -10,7 +10,7 @@ class BrazeClient(config: Config) extends StrictLogging {
 
   def sendEmail(emailData: IdentityBrazeEmailData, emailToken: String) : Either[Throwable, BrazeResponse] = {
 
-    logger.info(s"send BrazeEmail for email ${emailData.emailAddress} with token $emailToken with templateId ${emailData.templateId}")
+    logger.info(s"sending email via Braze - email data: $emailData")
 
     val sendRequest = BrazeSendRequest(config.brazeApiKey, emailData.templateId, List(BrazeRecipient(emailData.externalId, emailData.customFields + ("emailToken" -> emailToken))))
 

--- a/payment-failure/src/main/scala/com/gu/identity/paymentfailure/Lambda.scala
+++ b/payment-failure/src/main/scala/com/gu/identity/paymentfailure/Lambda.scala
@@ -27,17 +27,23 @@ object Lambda extends StrictLogging {
 
   def handler(event: SQSEvent, context: Context): Unit = {
 
-    logger.info(s"context :  $context")
-    logger.info(s"event :  $event")
-    logger.info(s"received message batch of size: ${event.getRecords.size}")
+    LambdaService.setAWSRequestId(context)
+
+    logger.info(s"received ${event.getRecords.size} messages - context: $context - event: $event")
 
     logger.info("initialising config and lambda service")
-    val config =  getConfig.valueOr(throw _)
+    val config = getConfig.valueOr { err =>
+      logger.error("unable to get config", err)
+      throw err
+    }
+
     val lambdaService = LambdaService.fromConfig(config)
 
     logger.info("config and services successfully initialised - processing events")
     lambdaService.processEvent(event).foreach {
-      case Left(throwable) => throw throwable
+      case Left(err) =>
+        logger.error(s"unable to process event $event", err)
+        throw err
       case _ => logger.info("process successful")
     }
   }

--- a/payment-failure/src/main/scala/com/gu/identity/paymentfailure/LambdaService.scala
+++ b/payment-failure/src/main/scala/com/gu/identity/paymentfailure/LambdaService.scala
@@ -1,6 +1,8 @@
 package com.gu.identity.paymentfailure
 
+import com.amazonaws.services.lambda.runtime.Context
 import com.amazonaws.services.lambda.runtime.events.SQSEvent
+import org.slf4j.MDC
 
 import scala.collection.JavaConverters._
 
@@ -26,5 +28,11 @@ object LambdaService {
     val sendEmailService = new SendEmailService(identityClient, brazeClient, config)
     new LambdaService(sqsService, sendEmailService)
   }
+
+  // Utility method to set the value of AWSRequestId in the mapped diagnostic context.
+  // Means that the AWS request id will be included in any log entries.
+  // See logback.xml and https://logback.qos.ch/manual/layouts.html for more details.
+  def setAWSRequestId(context: Context): Unit =
+    MDC.put("AWSRequestId", context.getAwsRequestId)
 }
 


### PR DESCRIPTION
Changes:
- logs error before throwing it
- sets the AWS request id in the mapped diagnostic context so that it will be included in any log entries
