### PR TITLE
add advice on re-handling messages on the dead letter queue

### DIFF
--- a/payment-failure/README.md
+++ b/payment-failure/README.md
@@ -27,3 +27,6 @@ event => email queue => [workflow](https://github.com/guardian/membership-workfl
   1. set the main SQS queue as the DLQ for the actual DLQ with Maximum Receives as 1
   2. view the content in DLQ (this will move the messages to the main queue as this is the DLQ for the actual DLQ)
   3. remove the setting so that the main queue is no more the DLQ of the actual DLQ
+  
+  __Note:__ you won't always want to put messages from the dead letter queue back on the main queue. For example, if
+  email validation fails, it will continue to fail.

--- a/payment-failure/README.md
+++ b/payment-failure/README.md
@@ -15,3 +15,15 @@ event => email queue => [workflow](https://github.com/guardian/membership-workfl
   document which records the architectural decisions made when setting up this lambda.
 - see [`test-payment-failure-email.sh`](https://github.com/guardian/membership-workflow/blob/master/dev/test-payment-failure-email.sh)
   in membership-workflow as a way of sending events which will invoke the lambda
+
+
+## FAQ:
+
+- _How do I send messages on the dead letter queue to the queue that the lambda reads from (so that message processing)
+  can be retried?_ 
+  
+  [This](https://stackoverflow.com/questions/25408158/best-way-to-move-messages-off-dlq-in-amazon-sqs)
+  Stackoverflow answer by Rajkumar provides a convenient way. In summary:
+  1. set the main SQS queue as the DLQ for the actual DLQ with Maximum Receives as 1
+  2. view the content in DLQ (this will move the messages to the main queue as this is the DLQ for the actual DLQ)
+  3. remove the setting so that the main queue is no more the DLQ of the actual DLQ


### PR DESCRIPTION
Note: the advice here doesn't just apply to the payment failure lambda; therefore, it could be moved in future (to somewhere more general). For now, put it here, as we have needed to do this a couple of times for this lambda already.