### PR TITLE
Accumulate errors using validated

### DIFF
--- a/payment-failure/build.sbt
+++ b/payment-failure/build.sbt
@@ -5,6 +5,8 @@ organization := "com.gu"
 scalaVersion := "2.12.6"
 val circeVersion = "0.10.1"
 
+addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.9.8")
+
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.0",
   "com.amazonaws" % "aws-lambda-java-events" % "2.2.2",

--- a/payment-failure/src/main/scala/com/gu/identity/paymentfailure/Lambda.scala
+++ b/payment-failure/src/main/scala/com/gu/identity/paymentfailure/Lambda.scala
@@ -50,7 +50,7 @@ object Lambda extends StrictLogging {
         // since we explicitly delete them from the queue (see LambdaService::processMessage()).
         errors => {
           val lambdaError = Error(errors)
-          logger.error(s"error occurred whilst processing event - $lambdaError")
+          logger.error(s"error occurred whilst processing event", lambdaError)
           throw lambdaError
         },
         _ => logger.info("event successfully processed")

--- a/payment-failure/src/main/scala/com/gu/identity/paymentfailure/Lambda.scala
+++ b/payment-failure/src/main/scala/com/gu/identity/paymentfailure/Lambda.scala
@@ -1,5 +1,6 @@
 package com.gu.identity.paymentfailure
 
+import cats.data.NonEmptyList
 import com.typesafe.scalalogging.StrictLogging
 import com.amazonaws.services.lambda.runtime.Context
 import com.amazonaws.services.lambda.runtime.events.SQSEvent
@@ -40,11 +41,25 @@ object Lambda extends StrictLogging {
     val lambdaService = LambdaService.fromConfig(config)
 
     logger.info("config and services successfully initialised - processing events")
-    lambdaService.processEvent(event).foreach {
-      case Left(err) =>
-        logger.error(s"unable to process event $event", err)
-        throw err
-      case _ => logger.info("process successful")
-    }
+    lambdaService.processEvent(event)
+      .fold(
+        // If there are any errors in processing the event, throw an exception.
+        // In which case, AWS will automatically put any messages handled by the respective lambda invocation
+        // back on the queue (so they can be retried).
+        // Note that messages that have been successfully processed won't be put back on the queue,
+        // since we explicitly delete them from the queue (see LambdaService::processMessage()).
+        errors => {
+          val lambdaError = Error(errors)
+          logger.error(s"error occurred whilst processing event - $lambdaError")
+          throw lambdaError
+        },
+        _ => logger.info("event successfully processed")
+      )
+  }
+
+  // Utility class for wrapping any errors returned from LambdaService::processEvent()
+  // Facilitates throwing an error which includes everything that has gone wrong.
+  case class Error(messageErrors: NonEmptyList[Throwable]) extends Exception {
+    override def getMessage: String = s"Lambda.Error: ${messageErrors.toList.mkString(" and ")}"
   }
 }

--- a/payment-failure/src/main/scala/com/gu/identity/paymentfailure/Lambda.scala
+++ b/payment-failure/src/main/scala/com/gu/identity/paymentfailure/Lambda.scala
@@ -45,7 +45,7 @@ object Lambda extends StrictLogging {
       .fold(
         // If there are any errors in processing the event, throw an exception.
         // In which case, AWS will automatically put any messages handled by the respective lambda invocation
-        // back on the queue (so they can be retried).
+        // back on the queue (so they can be retried), or dead letter queue if max retries have been exceeded.
         // Note that messages that have been successfully processed won't be put back on the queue,
         // since we explicitly delete them from the queue (see LambdaService::processMessage()).
         errors => {

--- a/payment-failure/src/main/scala/com/gu/identity/paymentfailure/LambdaService.scala
+++ b/payment-failure/src/main/scala/com/gu/identity/paymentfailure/LambdaService.scala
@@ -9,7 +9,7 @@ import org.slf4j.MDC
 
 import scala.collection.JavaConverters._
 
-class LambdaService private (sqsService: SqsService, sendEmailService: SendEmailService) {
+class LambdaService(sqsService: SqsService, sendEmailService: SendEmailService) {
 
   def processMessage(message: SQSMessage): Either[Throwable, BrazeResponse] =
     for {

--- a/payment-failure/src/main/scala/com/gu/identity/paymentfailure/LambdaService.scala
+++ b/payment-failure/src/main/scala/com/gu/identity/paymentfailure/LambdaService.scala
@@ -1,22 +1,34 @@
 package com.gu.identity.paymentfailure
 
+import cats.data.ValidatedNel
+import cats.implicits._
 import com.amazonaws.services.lambda.runtime.Context
 import com.amazonaws.services.lambda.runtime.events.SQSEvent
+import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage
 import org.slf4j.MDC
 
 import scala.collection.JavaConverters._
 
 class LambdaService private (sqsService: SqsService, sendEmailService: SendEmailService) {
 
-  def processEvent(event: SQSEvent): List[Either[Throwable, BrazeResponse]] =
-    event.getRecords.asScala.toList.map { message =>
-      for {
-        emailData <- sqsService.parseSingleMessage(message)
-        brazeResponse <- sendEmailService.sendEmail(emailData)
-        result <- sqsService.deleteMessage(message)
-        _ <- sqsService.processDeleteMessageResult(result)
-      } yield brazeResponse
-    }
+  def processMessage(message: SQSMessage): Either[Throwable, BrazeResponse] =
+    for {
+      emailData <- sqsService.parseSingleMessage(message)
+      brazeResponse <- sendEmailService.sendEmail(emailData)
+      // Deleting a message from the queue will mean that even if the lambda throws an error
+      // to signify that not all messages in the event have been processed successfully,
+      // messages that have been processed successfully will not be put back on the queue.
+      result <- sqsService.deleteMessage(message)
+      _ <- sqsService.processDeleteMessageResult(result)
+    } yield brazeResponse
+
+  // Returns a list of errors if there has been at least one error processing the messages.
+  // Otherwise returns a list of the successful Braze responses.
+  def processEvent(event: SQSEvent): ValidatedNel[Throwable, List[BrazeResponse]] =
+    event.getRecords.asScala.toList
+      .traverse[ValidatedNel[Throwable, ?], BrazeResponse] { message =>
+        processMessage(message).toValidatedNel
+      }
 }
 
 object LambdaService {

--- a/payment-failure/src/test/scala/com/gu/identity/paymentfailure/LambdaServiceTest.scala
+++ b/payment-failure/src/test/scala/com/gu/identity/paymentfailure/LambdaServiceTest.scala
@@ -1,0 +1,80 @@
+package com.gu.identity.paymentfailure
+
+
+import java.util
+
+import com.amazonaws.services.lambda.runtime.events.SQSEvent
+import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage
+import com.amazonaws.services.sqs.model.DeleteMessageResult
+import org.mockito.Mockito._
+import org.scalatest.mockito.MockitoSugar
+import org.scalatest.{EitherValues, Matchers, WordSpec}
+
+class LambdaServiceTest extends WordSpec with Matchers with MockitoSugar with EitherValues {
+
+  val sqsService = mock[SqsService]
+  val sendEmailService = mock[SendEmailService]
+
+  val lambdaService = new LambdaService(sqsService, sendEmailService)
+
+  // Mock the flow of a message being successfully processed
+
+  val message = mock[SQSMessage]
+
+  val emailData = mock[IdentityBrazeEmailData]
+  when(sqsService.parseSingleMessage(message)).thenReturn(Right(emailData))
+
+  val brazeResponse = mock[BrazeResponse]
+  when(sendEmailService.sendEmail(emailData)).thenReturn(Right(brazeResponse))
+
+  val deleteMessageResult = mock[DeleteMessageResult]
+  when(sqsService.deleteMessage(message)).thenReturn(Right(deleteMessageResult))
+
+  when(sqsService.processDeleteMessageResult(deleteMessageResult)).thenReturn(Right(()))
+
+  // Mock the flow of a message not being successfully processed
+
+  val invalidMessage = mock[SQSMessage]
+
+  val parseError = mock[Throwable]
+  when(sqsService.parseSingleMessage(invalidMessage)).thenReturn(Left(parseError))
+
+  "A Lambda service" when {
+
+    "it processes all messages successfully" should {
+
+      "return a list of all the Braze responses" in {
+
+        val event = mock[SQSEvent]
+
+        when(event.getRecords).thenReturn(util.Arrays.asList(message, message))
+
+        lambdaService.processEvent(event).toEither.right.value.shouldEqual(List(brazeResponse, brazeResponse))
+      }
+    }
+
+    "it processes no messages successfully" should {
+
+      "return a list of all the errors" in {
+
+        val event = mock[SQSEvent]
+
+        when(event.getRecords).thenReturn(util.Arrays.asList(invalidMessage, invalidMessage, invalidMessage))
+
+        lambdaService.processEvent(event).toEither.left.value.toList.shouldEqual(List(parseError, parseError, parseError))
+      }
+    }
+
+    "it processes some messages unsuccessfully" should {
+
+      "return a list with those errors" in {
+
+        val event = mock[SQSEvent]
+
+        when(event.getRecords).thenReturn(util.Arrays.asList(invalidMessage, message, invalidMessage))
+
+        lambdaService.processEvent(event).toEither.left.value.toList.shouldEqual(List(parseError, parseError))
+      }
+    }
+  }
+}

--- a/payment-failure/src/test/scala/com/gu/identity/paymentfailure/SendEmailServiceTest.scala
+++ b/payment-failure/src/test/scala/com/gu/identity/paymentfailure/SendEmailServiceTest.scala
@@ -1,9 +1,8 @@
-package com.gu.identity.paymentfailure.sendEmailService
+package com.gu.identity.paymentfailure
 
-import com.gu.identity.paymentfailure._
-import org.scalatest.{Matchers, WordSpec}
-import org.scalatest.mockito.MockitoSugar
 import org.mockito.Mockito._
+import org.scalatest.mockito.MockitoSugar
+import org.scalatest.{Matchers, WordSpec}
 
 class SendEmailServiceTest extends WordSpec with Matchers with MockitoSugar {
 

--- a/payment-failure/src/test/scala/com/gu/identity/paymentfailure/SqsServiceTest.scala
+++ b/payment-failure/src/test/scala/com/gu/identity/paymentfailure/SqsServiceTest.scala
@@ -1,12 +1,11 @@
-package com.gu.identity.paymentfailure.sqsService
+package com.gu.identity.paymentfailure
 
 import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage
-import com.gu.identity.paymentfailure.{Config, IdentityBrazeEmailData, SqsService}
 import io.circe.CursorOp.DownField
 import io.circe.DecodingFailure
-import org.scalatest.{Matchers, WordSpec}
-import org.scalatest.mockito.MockitoSugar
 import org.mockito.Mockito._
+import org.scalatest.mockito.MockitoSugar
+import org.scalatest.{Matchers, WordSpec}
 
 class SqsServiceTest extends WordSpec with Matchers with MockitoSugar {
 


### PR DESCRIPTION
Here's a (possibly) controversial PR 😉

We've done (IMO) a nice job of handling errors in this lambda using the `Either[Throwable, ?]` monad. Let's leverage this to accumulate the errors when handling a batch of messages.

The main advantage (apart from it being more idiomatic with this style of Scala - not sure if that counts), is that we accumulate the errors and then throw them all at once (so no information is lost), rather than throwing on the first error encountered.

I've also added a few more comments explaining what throwing an error means in the context of a lambda with a queue as its event source.