### PR TITLE
Still send email if email encryption fails

### DIFF
--- a/payment-failure/src/main/scala/com/gu/identity/paymentfailure/BrazeClient.scala
+++ b/payment-failure/src/main/scala/com/gu/identity/paymentfailure/BrazeClient.scala
@@ -2,31 +2,32 @@ package com.gu.identity.paymentfailure
 
 import com.typesafe.scalalogging.StrictLogging
 import cats.syntax.either._
+import io.circe.parser.decode
 import io.circe.syntax._
 import scalaj.http.Http
 
 
 class BrazeClient(config: Config) extends StrictLogging {
 
-  def sendEmail(emailData: IdentityBrazeEmailData, emailToken: String) : Either[Throwable, BrazeResponse] = {
+  def sendEmail(request: BrazeSendRequest) : Either[Throwable, BrazeResponse] = {
 
-    logger.info(s"sending email via Braze - email data: $emailData")
-
-    val sendRequest = BrazeSendRequest(config.brazeApiKey, emailData.templateId, List(BrazeRecipient(emailData.externalId, emailData.customFields + ("emailToken" -> emailToken))))
+    logger.info(s"sending email via Braze - request data: $request")
 
     Either.catchNonFatal(
       Http(s"${config.brazeApiHost}/campaigns/trigger/send")
       .header("content-type", "application/json")
-      .postData(sendRequest.asJson.toString)
+      .postData(request.asJson.toString)
       .asString
-    ).flatMap(postResponse =>
-        if (postResponse.isSuccess) {
-          logger.info(s"Successfully sent email from Braze for email: ${emailData.emailAddress} with templateId ${emailData.templateId}")
-          io.circe.parser.decode[BrazeResponse](postResponse.body)
-        } else {
-          logger.error(s"Failed to send email from Braze, error with status ${postResponse.code} - error ${postResponse.body}")
-          Left( new Exception(s"sendEmail error with status ${postResponse.code} - error ${postResponse.body}"))
-        }
-    )
+    ).flatMap { response =>
+      val body = response.body
+      if (response.isSuccess) {
+        logger.info(s"successfully executed braze request: $request - response body: $body")
+        decode[BrazeResponse](body)
+      } else {
+        val message = s"failed to send email from Braze, error with status ${response.code} - error $body"
+        logger.error(message)
+        Left(new Exception(message))
+      }
+    }
   }
 }

--- a/payment-failure/src/main/scala/com/gu/identity/paymentfailure/Model.scala
+++ b/payment-failure/src/main/scala/com/gu/identity/paymentfailure/Model.scala
@@ -20,6 +20,7 @@ object BrazeRecipient {
 case class BrazeSendRequest(api_key: String, campaign_id: String, recipients: Seq[BrazeRecipient])
 
 object BrazeSendRequest {
+
   implicit val BrazeSendRequestEncoder: Encoder[BrazeSendRequest] = deriveEncoder[BrazeSendRequest]
 }
 

--- a/payment-failure/src/main/scala/com/gu/identity/paymentfailure/SendEmailService.scala
+++ b/payment-failure/src/main/scala/com/gu/identity/paymentfailure/SendEmailService.scala
@@ -1,11 +1,35 @@
 package com.gu.identity.paymentfailure
 
-class SendEmailService (identityClient: IdentityClient, brazeClient: BrazeClient, config: Config){
+import com.typesafe.scalalogging.StrictLogging
+
+class SendEmailService(identityClient: IdentityClient, brazeClient: BrazeClient, config: Config) extends StrictLogging {
+
+  // Recover from error by allowing for the token to be optional.
+  // Would rather send an email without a token than not at all.
+  def encryptEmail(email: String): Option[String] =
+    identityClient.encryptEmail(email)
+    .fold(
+      err => {
+        // TODO: monitor these errors
+        // Log this error as otherwise on folding to an option, this information would be lost.
+        logger.error(s"unable to encrypt email $email", err)
+        Option.empty[String]
+      },
+      response => Some(response.encryptedEmail)
+    )
 
   def sendEmail(emailData: IdentityBrazeEmailData): Either[Throwable, BrazeResponse] = {
-    for {
-      encryptedTokenResponse <- identityClient.encryptEmail(emailData.emailAddress)
-      brazeResponse <- brazeClient.sendEmail(emailData, encryptedTokenResponse.encryptedEmail)
-    } yield brazeResponse
+    val encryptedEmail = encryptEmail(emailData.emailAddress)
+    val request = SendEmailService.brazeSendRequest(config.brazeApiKey, emailData, encryptedEmail)
+    brazeClient.sendEmail(request)
+  }
+}
+
+object SendEmailService {
+
+  def brazeSendRequest(brazeApiKey: String, emailData: IdentityBrazeEmailData, encryptedEmail: Option[String]): BrazeSendRequest = {
+    val customFields = encryptedEmail.fold(emailData.customFields)(token => emailData.customFields + ("emailToken" -> token))
+    val recipient = BrazeRecipient(emailData.externalId, customFields)
+    BrazeSendRequest(brazeApiKey, emailData.templateId, List(recipient))
   }
 }

--- a/payment-failure/src/test/scala/com/gu/identity/paymentfailure/sendEmailService/SendEmailServiceTest.scala
+++ b/payment-failure/src/test/scala/com/gu/identity/paymentfailure/sendEmailService/SendEmailServiceTest.scala
@@ -12,31 +12,62 @@ class SendEmailServiceTest extends WordSpec with Matchers with MockitoSugar {
     val identityClient = mock[IdentityClient]
     val brazeClient = mock[BrazeClient]
     val sendEmailService = new SendEmailService(identityClient, brazeClient, config)
+
+    when(config.brazeApiKey).thenReturn("braze-api-key")
   }
 
   "The sendEmail method" should {
-    "encrypt an email then trigger an email in Braze" in new TestFixture {
+
+    "trigger an email in Braze with the emailToken trigger property, if email is successfully encrypted" in new TestFixture {
 
       val emailData = IdentityBrazeEmailData("1111", "test@test.com", "templateIdMock", Map("first name" -> "test name"))
 
       when(identityClient.encryptEmail("test@test.com")).thenReturn(Right(IdentityEmailTokenResponse("OK", "encryptedEmailString")))
-      when(brazeClient.sendEmail(emailData, "encryptedEmailString")).thenReturn(Right(BrazeResponse("success")))
+
+      val brazeRequest = BrazeSendRequest(
+        api_key = "braze-api-key",
+        campaign_id = "templateIdMock",
+        recipients = List(
+          BrazeRecipient(
+            external_user_id = "1111",
+            trigger_properties = Map(
+              "first name" -> "test name",
+              "emailToken" -> "encryptedEmailString"
+            )
+          )
+        )
+      )
+
       sendEmailService.sendEmail(emailData)
 
       verify(identityClient, times(1)).encryptEmail("test@test.com")
-      verify(brazeClient, times(1)).sendEmail(emailData, "encryptedEmailString")
+      verify(brazeClient, times(1)).sendEmail(brazeRequest)
     }
 
-    "not trigger a braze email if email encryption fails" in new TestFixture {
+    "trigger an email in Braze without the emailToken trigger property, if email encryption fails" in new TestFixture {
+
       val emailData = IdentityBrazeEmailData("1111", "test@test.com", "templateIdMock", Map("first name" -> "test name"))
 
       val mockException = mock[Exception]
       when(identityClient.encryptEmail("test@test.com")).thenReturn(Left(mockException))
 
+      val brazeRequest = BrazeSendRequest(
+        api_key = "braze-api-key",
+        campaign_id = "templateIdMock",
+        recipients = List(
+          BrazeRecipient(
+            external_user_id = "1111",
+            trigger_properties = Map(
+              "first name" -> "test name"
+            )
+          )
+        )
+      )
+
       sendEmailService.sendEmail(emailData)
 
       verify(identityClient, times(1)).encryptEmail("test@test.com")
-      verify(brazeClient, never()).sendEmail(emailData, "encryptedEmailString")
+      verify(brazeClient, times(1)).sendEmail(brazeRequest)
 
     }
   }


### PR DESCRIPTION
Currently we don't send a payment failure email if email encryption fails. Change this so that the email is still sent: preferable an email with no encrypted email token than none at all. 

Note, this is not a regression in that it was the current behaviour when emails were sent by membership-workflow.

The (single) cause of email encryption failure witnessed in PROD so far is that the email address is in on a blocked domain. One fix for this would be to allow the encryption of emails on blocked domains.

cc @jacobwinch