### PR TITLE
Generate an AB test to test encrypted email token

### DIFF
--- a/payment-failure/src/main/scala/com/gu/identity/paymentfailure/BrazeClient.scala
+++ b/payment-failure/src/main/scala/com/gu/identity/paymentfailure/BrazeClient.scala
@@ -31,3 +31,14 @@ class BrazeClient(config: Config) extends StrictLogging {
     }
   }
 }
+
+object BrazeClient {
+
+  // Valid keys of trigger properties that are utilised in Braze templates.
+  object TriggerProperties {
+    val emailToken = "emailToken"
+    val autoSignInToken = "autoSignInToken"
+    val abName = "abName"
+    val abVariant = "abVariant"
+  }
+}

--- a/payment-failure/src/main/scala/com/gu/identity/paymentfailure/BrazeEmailService.scala
+++ b/payment-failure/src/main/scala/com/gu/identity/paymentfailure/BrazeEmailService.scala
@@ -94,6 +94,7 @@ class BrazeEmailServiceWithEncryptedBrazeEmailTest(
       customFields = testVariantToCustomFields(variant)
       response <- sendEmailWithCustomFields(emailData, customFields)
     } yield {
+      logger.info("braze email sent with encrypted email test data")
       response
     }).recoverWith { case err =>
       // Failure to send an email with the encrypted email test should not prevent the email being sent,

--- a/payment-failure/src/main/scala/com/gu/identity/paymentfailure/BrazeEmailService.scala
+++ b/payment-failure/src/main/scala/com/gu/identity/paymentfailure/BrazeEmailService.scala
@@ -94,7 +94,7 @@ class BrazeEmailServiceWithEncryptedBrazeEmailTest(
       customFields = testVariantToCustomFields(variant)
       response <- sendEmailWithCustomFields(emailData, customFields)
     } yield {
-      logger.info("braze email sent with encrypted email test data")
+      logger.info(s"braze email sent with encrypted email test data - variant data: $variant")
       response
     }).recoverWith { case err =>
       // Failure to send an email with the encrypted email test should not prevent the email being sent,

--- a/payment-failure/src/main/scala/com/gu/identity/paymentfailure/EncryptedEmailTest.scala
+++ b/payment-failure/src/main/scala/com/gu/identity/paymentfailure/EncryptedEmailTest.scala
@@ -36,7 +36,7 @@ object EncryptedEmailTest {
       override val name: String = "control"
     }
 
-    case class EncryptedEmail private(token: String) extends Variant {
+    case class EncryptedEmail private (token: String) extends Variant {
       override val name: String = "email-token"
     }
   }

--- a/payment-failure/src/main/scala/com/gu/identity/paymentfailure/EncryptedEmailTest.scala
+++ b/payment-failure/src/main/scala/com/gu/identity/paymentfailure/EncryptedEmailTest.scala
@@ -1,0 +1,43 @@
+package com.gu.identity.paymentfailure
+
+import cats.syntax.either._
+import com.gu.identity.paymentfailure.IdentityClient.{AutoSignInLinkRequestBody, IdentityEmailTokenRequest}
+
+import scala.util.Random
+
+class EncryptedEmailTest(identityClient: IdentityClient) {
+
+  import EncryptedEmailTest._
+
+  def generateVariant(identityId: String, email: String): Either[Throwable, Variant] = {
+    if (Random.nextDouble() < 1d / 2d) {
+      Right(Variant.Control)
+    } else {
+      val requestBody = IdentityEmailTokenRequest(email)
+      identityClient.encryptEmail(requestBody)
+        .bimap(
+          err => new RuntimeException("unable to create email token", err),
+          response => Variant.EncryptedEmail(response.encryptedEmail)
+        )
+    }
+  }
+}
+
+object EncryptedEmailTest {
+
+  sealed trait Variant {
+    final val testName: String = "auto-sign-in-test"
+    def name: String
+  }
+
+  object Variant {
+
+    case object Control extends Variant {
+      override val name: String = "control"
+    }
+
+    case class EncryptedEmail private(token: String) extends Variant {
+      override val name: String = "email-token"
+    }
+  }
+}

--- a/payment-failure/src/main/scala/com/gu/identity/paymentfailure/Lambda.scala
+++ b/payment-failure/src/main/scala/com/gu/identity/paymentfailure/Lambda.scala
@@ -38,7 +38,9 @@ object Lambda extends StrictLogging {
       throw err
     }
 
-    val lambdaService = LambdaService.fromConfig(config)
+    // Currently running the encrypted email test
+    // TODO: switch back to using DefaultBrazeEmailService when test is finished
+    val lambdaService = LambdaService.encryptedEmailTest(config)
 
     logger.info("config and services successfully initialised - processing events")
     lambdaService.processEvent(event)

--- a/payment-failure/src/main/scala/com/gu/identity/paymentfailure/LambdaService.scala
+++ b/payment-failure/src/main/scala/com/gu/identity/paymentfailure/LambdaService.scala
@@ -14,7 +14,7 @@ class LambdaService(sqsService: SqsService, sendEmailService: SendEmailService) 
   def processMessage(message: SQSMessage): Either[Throwable, BrazeResponse] =
     for {
       emailData <- sqsService.parseSingleMessage(message)
-      brazeResponse <- sendEmailService.sendEmailSignInTokens(emailData)
+      brazeResponse <- sendEmailService.sendEmailWithSignInTokens(emailData)
       // Deleting a message from the queue will mean that even if the lambda throws an error
       // to signify that not all messages in the event have been processed successfully,
       // messages that have been processed successfully will not be put back on the queue.

--- a/payment-failure/src/main/scala/com/gu/identity/paymentfailure/LambdaService.scala
+++ b/payment-failure/src/main/scala/com/gu/identity/paymentfailure/LambdaService.scala
@@ -9,12 +9,12 @@ import org.slf4j.MDC
 
 import scala.collection.JavaConverters._
 
-class LambdaService(sqsService: SqsService, sendEmailService: SendEmailService) {
+class LambdaService(sqsService: SqsService, brazeEmailService: BrazeEmailService) {
 
   def processMessage(message: SQSMessage): Either[Throwable, BrazeResponse] =
     for {
       emailData <- sqsService.parseSingleMessage(message)
-      brazeResponse <- sendEmailService.sendEmailWithSignInTokens(emailData)
+      brazeResponse <- brazeEmailService.sendEmail(emailData)
       // Deleting a message from the queue will mean that even if the lambda throws an error
       // to signify that not all messages in the event have been processed successfully,
       // messages that have been processed successfully will not be put back on the queue.
@@ -33,12 +33,20 @@ class LambdaService(sqsService: SqsService, sendEmailService: SendEmailService) 
 
 object LambdaService {
 
-  def fromConfig(config: Config): LambdaService = {
+  def default(config: Config): LambdaService = {
+    val identityClient = new IdentityClient(config)
+    val sqsService = new SqsService(config)
+    val brazeClient = new BrazeClient(config)
+    val sendEmailService = new DefaultBrazeEmailService(identityClient, brazeClient, config)
+    new LambdaService(sqsService, sendEmailService)
+  }
+
+  def encryptedEmailTest(config: Config): LambdaService = {
     val identityClient = new IdentityClient(config)
     val sqsService = new SqsService(config)
     val brazeClient = new BrazeClient(config)
     val encryptedEmailTest = new EncryptedEmailTest(identityClient)
-    val sendEmailService = new SendEmailService(identityClient, brazeClient, config, encryptedEmailTest)
+    val sendEmailService = new BrazeEmailServiceWithEncryptedBrazeEmailTest(brazeClient, encryptedEmailTest, config)
     new LambdaService(sqsService, sendEmailService)
   }
 

--- a/payment-failure/src/main/scala/com/gu/identity/paymentfailure/LambdaService.scala
+++ b/payment-failure/src/main/scala/com/gu/identity/paymentfailure/LambdaService.scala
@@ -14,7 +14,7 @@ class LambdaService(sqsService: SqsService, sendEmailService: SendEmailService) 
   def processMessage(message: SQSMessage): Either[Throwable, BrazeResponse] =
     for {
       emailData <- sqsService.parseSingleMessage(message)
-      brazeResponse <- sendEmailService.sendEmail(emailData)
+      brazeResponse <- sendEmailService.sendEmailSignInTokens(emailData)
       // Deleting a message from the queue will mean that even if the lambda throws an error
       // to signify that not all messages in the event have been processed successfully,
       // messages that have been processed successfully will not be put back on the queue.
@@ -37,7 +37,8 @@ object LambdaService {
     val identityClient = new IdentityClient(config)
     val sqsService = new SqsService(config)
     val brazeClient = new BrazeClient(config)
-    val sendEmailService = new SendEmailService(identityClient, brazeClient, config)
+    val encryptedEmailTest = new EncryptedEmailTest(identityClient)
+    val sendEmailService = new SendEmailService(identityClient, brazeClient, config, encryptedEmailTest)
     new LambdaService(sqsService, sendEmailService)
   }
 

--- a/payment-failure/src/main/scala/com/gu/identity/paymentfailure/SendEmailService.scala
+++ b/payment-failure/src/main/scala/com/gu/identity/paymentfailure/SendEmailService.scala
@@ -52,7 +52,7 @@ class SendEmailService(
   // Identity frontend can then decide which piece of information to utilise.
   // This method is currently be called by the lambda since an AB test is being run.
   // Keep it as it will most likely be used once the AB test is finished.
-  def sendEmailSignInTokens(emailData: IdentityBrazeEmailData): Either[Throwable, BrazeResponse] = {
+  def sendEmailWithSignInTokens(emailData: IdentityBrazeEmailData): Either[Throwable, BrazeResponse] = {
     val encryptedEmailToken = encryptEmail(emailData.emailAddress)
     val autoSignInToken = createAutoSignInToken(emailData.externalId, emailData.emailAddress)
     val tokenFields = List(

--- a/payment-failure/src/test/scala/com/gu/identity/paymentfailure/BrazeEmailServiceTest.scala
+++ b/payment-failure/src/test/scala/com/gu/identity/paymentfailure/BrazeEmailServiceTest.scala
@@ -7,14 +7,13 @@ import org.scalatest.mockito.MockitoSugar
 import org.mockito.Matchers._
 import org.mockito.Mockito._
 
-class SendEmailServiceTest extends WordSpec with Matchers with MockitoSugar {
+class BrazeEmailServiceTest extends WordSpec with Matchers with MockitoSugar {
 
   trait TestFixture {
     val config = mock[Config]
     val identityClient = mock[IdentityClient]
     val brazeClient = mock[BrazeClient]
-    val encryptedEmailTest = mock[EncryptedEmailTest]
-    val sendEmailService = new SendEmailService(identityClient, brazeClient, config, encryptedEmailTest)
+    val sendEmailService = new DefaultBrazeEmailService(identityClient, brazeClient, config)
 
     when(config.brazeApiKey).thenReturn("braze-api-key")
   }
@@ -31,7 +30,7 @@ class SendEmailServiceTest extends WordSpec with Matchers with MockitoSugar {
         when(identityClient.encryptEmail(any[IdentityEmailTokenRequest]))
             .thenReturn(Right(IdentityEmailTokenResponse("ok", "email-token")))
 
-        sendEmailService.sendEmailWithSignInTokens(
+        sendEmailService.sendEmail(
           IdentityBrazeEmailData(
             externalId = "identity-id",
             emailAddress = "email",
@@ -70,7 +69,7 @@ class SendEmailServiceTest extends WordSpec with Matchers with MockitoSugar {
         when(identityClient.encryptEmail(any[IdentityEmailTokenRequest]))
           .thenReturn(Left(new Exception))
 
-        sendEmailService.sendEmailWithSignInTokens(
+        sendEmailService.sendEmail(
           IdentityBrazeEmailData(
             externalId = "identity-id",
             emailAddress = "email",
@@ -108,7 +107,7 @@ class SendEmailServiceTest extends WordSpec with Matchers with MockitoSugar {
         when(identityClient.encryptEmail(any[IdentityEmailTokenRequest]))
           .thenReturn(Right(IdentityEmailTokenResponse("ok", "email-token")))
 
-        sendEmailService.sendEmailWithSignInTokens(
+        sendEmailService.sendEmail(
           IdentityBrazeEmailData(
             externalId = "identity-id",
             emailAddress = "email",
@@ -146,7 +145,7 @@ class SendEmailServiceTest extends WordSpec with Matchers with MockitoSugar {
         when(identityClient.encryptEmail(any[IdentityEmailTokenRequest]))
           .thenReturn(Left(new Exception))
 
-        sendEmailService.sendEmailWithSignInTokens(
+        sendEmailService.sendEmail(
           IdentityBrazeEmailData(
             externalId = "identity-id",
             emailAddress = "email",

--- a/payment-failure/src/test/scala/com/gu/identity/paymentfailure/LambdaServiceTest.scala
+++ b/payment-failure/src/test/scala/com/gu/identity/paymentfailure/LambdaServiceTest.scala
@@ -25,7 +25,7 @@ class LambdaServiceTest extends WordSpec with Matchers with MockitoSugar with Ei
   when(sqsService.parseSingleMessage(message)).thenReturn(Right(emailData))
 
   val brazeResponse = mock[BrazeResponse]
-  when(sendEmailService.sendEmail(emailData)).thenReturn(Right(brazeResponse))
+  when(sendEmailService.sendEmailSignInTokens(emailData)).thenReturn(Right(brazeResponse))
 
   val deleteMessageResult = mock[DeleteMessageResult]
   when(sqsService.deleteMessage(message)).thenReturn(Right(deleteMessageResult))

--- a/payment-failure/src/test/scala/com/gu/identity/paymentfailure/LambdaServiceTest.scala
+++ b/payment-failure/src/test/scala/com/gu/identity/paymentfailure/LambdaServiceTest.scala
@@ -25,7 +25,7 @@ class LambdaServiceTest extends WordSpec with Matchers with MockitoSugar with Ei
   when(sqsService.parseSingleMessage(message)).thenReturn(Right(emailData))
 
   val brazeResponse = mock[BrazeResponse]
-  when(sendEmailService.sendEmailSignInTokens(emailData)).thenReturn(Right(brazeResponse))
+  when(sendEmailService.sendEmailWithSignInTokens(emailData)).thenReturn(Right(brazeResponse))
 
   val deleteMessageResult = mock[DeleteMessageResult]
   when(sqsService.deleteMessage(message)).thenReturn(Right(deleteMessageResult))

--- a/payment-failure/src/test/scala/com/gu/identity/paymentfailure/LambdaServiceTest.scala
+++ b/payment-failure/src/test/scala/com/gu/identity/paymentfailure/LambdaServiceTest.scala
@@ -13,7 +13,7 @@ import org.scalatest.{EitherValues, Matchers, WordSpec}
 class LambdaServiceTest extends WordSpec with Matchers with MockitoSugar with EitherValues {
 
   val sqsService = mock[SqsService]
-  val sendEmailService = mock[SendEmailService]
+  val sendEmailService = mock[DefaultBrazeEmailService]
 
   val lambdaService = new LambdaService(sqsService, sendEmailService)
 
@@ -25,7 +25,7 @@ class LambdaServiceTest extends WordSpec with Matchers with MockitoSugar with Ei
   when(sqsService.parseSingleMessage(message)).thenReturn(Right(emailData))
 
   val brazeResponse = mock[BrazeResponse]
-  when(sendEmailService.sendEmailWithSignInTokens(emailData)).thenReturn(Right(brazeResponse))
+  when(sendEmailService.sendEmail(emailData)).thenReturn(Right(brazeResponse))
 
   val deleteMessageResult = mock[DeleteMessageResult]
   when(sqsService.deleteMessage(message)).thenReturn(Right(deleteMessageResult))

--- a/payment-failure/src/test/scala/com/gu/identity/paymentfailure/SendEmailServiceTest.scala
+++ b/payment-failure/src/test/scala/com/gu/identity/paymentfailure/SendEmailServiceTest.scala
@@ -31,7 +31,7 @@ class SendEmailServiceTest extends WordSpec with Matchers with MockitoSugar {
         when(identityClient.encryptEmail(any[IdentityEmailTokenRequest]))
             .thenReturn(Right(IdentityEmailTokenResponse("ok", "email-token")))
 
-        sendEmailService.sendEmailSignInTokens(
+        sendEmailService.sendEmailWithSignInTokens(
           IdentityBrazeEmailData(
             externalId = "identity-id",
             emailAddress = "email",
@@ -70,7 +70,7 @@ class SendEmailServiceTest extends WordSpec with Matchers with MockitoSugar {
         when(identityClient.encryptEmail(any[IdentityEmailTokenRequest]))
           .thenReturn(Left(new Exception))
 
-        sendEmailService.sendEmailSignInTokens(
+        sendEmailService.sendEmailWithSignInTokens(
           IdentityBrazeEmailData(
             externalId = "identity-id",
             emailAddress = "email",
@@ -108,7 +108,7 @@ class SendEmailServiceTest extends WordSpec with Matchers with MockitoSugar {
         when(identityClient.encryptEmail(any[IdentityEmailTokenRequest]))
           .thenReturn(Right(IdentityEmailTokenResponse("ok", "email-token")))
 
-        sendEmailService.sendEmailSignInTokens(
+        sendEmailService.sendEmailWithSignInTokens(
           IdentityBrazeEmailData(
             externalId = "identity-id",
             emailAddress = "email",
@@ -146,7 +146,7 @@ class SendEmailServiceTest extends WordSpec with Matchers with MockitoSugar {
         when(identityClient.encryptEmail(any[IdentityEmailTokenRequest]))
           .thenReturn(Left(new Exception))
 
-        sendEmailService.sendEmailSignInTokens(
+        sendEmailService.sendEmailWithSignInTokens(
           IdentityBrazeEmailData(
             externalId = "identity-id",
             emailAddress = "email",

--- a/payment-failure/src/test/scala/com/gu/identity/paymentfailure/SendEmailServiceTest.scala
+++ b/payment-failure/src/test/scala/com/gu/identity/paymentfailure/SendEmailServiceTest.scala
@@ -13,7 +13,8 @@ class SendEmailServiceTest extends WordSpec with Matchers with MockitoSugar {
     val config = mock[Config]
     val identityClient = mock[IdentityClient]
     val brazeClient = mock[BrazeClient]
-    val sendEmailService = new SendEmailService(identityClient, brazeClient, config)
+    val encryptedEmailTest = mock[EncryptedEmailTest]
+    val sendEmailService = new SendEmailService(identityClient, brazeClient, config, encryptedEmailTest)
 
     when(config.brazeApiKey).thenReturn("braze-api-key")
   }
@@ -30,7 +31,7 @@ class SendEmailServiceTest extends WordSpec with Matchers with MockitoSugar {
         when(identityClient.encryptEmail(any[IdentityEmailTokenRequest]))
             .thenReturn(Right(IdentityEmailTokenResponse("ok", "email-token")))
 
-        sendEmailService.sendEmail(
+        sendEmailService.sendEmailSignInTokens(
           IdentityBrazeEmailData(
             externalId = "identity-id",
             emailAddress = "email",
@@ -69,7 +70,7 @@ class SendEmailServiceTest extends WordSpec with Matchers with MockitoSugar {
         when(identityClient.encryptEmail(any[IdentityEmailTokenRequest]))
           .thenReturn(Left(new Exception))
 
-        sendEmailService.sendEmail(
+        sendEmailService.sendEmailSignInTokens(
           IdentityBrazeEmailData(
             externalId = "identity-id",
             emailAddress = "email",
@@ -107,7 +108,7 @@ class SendEmailServiceTest extends WordSpec with Matchers with MockitoSugar {
         when(identityClient.encryptEmail(any[IdentityEmailTokenRequest]))
           .thenReturn(Right(IdentityEmailTokenResponse("ok", "email-token")))
 
-        sendEmailService.sendEmail(
+        sendEmailService.sendEmailSignInTokens(
           IdentityBrazeEmailData(
             externalId = "identity-id",
             emailAddress = "email",
@@ -145,7 +146,7 @@ class SendEmailServiceTest extends WordSpec with Matchers with MockitoSugar {
         when(identityClient.encryptEmail(any[IdentityEmailTokenRequest]))
           .thenReturn(Left(new Exception))
 
-        sendEmailService.sendEmail(
+        sendEmailService.sendEmailSignInTokens(
           IdentityBrazeEmailData(
             externalId = "identity-id",
             emailAddress = "email",


### PR DESCRIPTION
This PR has quite a big diff (relatively). I decided to make the `SendEmailService` (renamed to `BrazeEmailService`) a trait to allow for different implementations. This means that the default email service can be (temporarily) be swapped out for other services (in this instance to run the encrypted email token test). What this means in future is that similar changes won't touch too many lines of pre-existing code; just the writing of new code. In addition to making subsequent PRs easier to review, it also means that the tests relating to the email service don't have to be re-written on every change.