### PR TITLE
Add retention period for cloud watch logs

### DIFF
--- a/payment-failure/cloud-formation.yaml
+++ b/payment-failure/cloud-formation.yaml
@@ -103,6 +103,12 @@ Resources:
       Timeout: 30
       MemorySize: 512
 
+  PaymentFailureLambdaLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub /aws/lambda/${PaymentFailureLambda}
+      RetentionInDays: 14
+
   PaymentFailureDeadLetterQueue:
     Type: AWS::SQS::Queue
     Properties:


### PR DESCRIPTION
Note that since this log group wasn't initially created by the cloud formation, we need to delete the respective log group before applying the stack changes. Otherwise you get a `CREATE_FAILED` with message e.g. `/aws/lambda/PaymentFailureLambda-CODE already exists`. This has been tested on CODE.