### PR TITLE
Update test name of auto sign-in test

### DIFF
--- a/payment-failure/src/main/scala/com/gu/identity/paymentfailure/abtest/AutoSignInTest.scala
+++ b/payment-failure/src/main/scala/com/gu/identity/paymentfailure/abtest/AutoSignInTest.scala
@@ -39,7 +39,7 @@ class AutoSignInTest(identityClient: IdentityClient) extends VariantGenerator {
 
 object AutoSignInTest {
 
-  val testName = "auto-sign-in-token-test"
+  val testName = "auto-sign-in-token-test-v2"
 
   val controlVariant = Variant(testName, variantName = "control")
 


### PR DESCRIPTION
Until today, the AST wasn't working correctly with the `/reauthenticate` endpoint. Now this has been fixed, update the test name to facilitate analytics on AST performance (i.e. can query by test name rather than test name and date to exclude invalid data).