### PR TITLE
handle user not found error

### DIFF
--- a/payment-failure/src/main/scala/com/gu/identity/paymentfailure/BrazeEmailService.scala
+++ b/payment-failure/src/main/scala/com/gu/identity/paymentfailure/BrazeEmailService.scala
@@ -101,10 +101,9 @@ class BrazeEmailServiceWithAbTest(
       // If this is a UserIneligibleForAbTest error (which, for example, can be caused by a user not meeting the
       // requirements to be sent an auto sign in token), we still want to send the email but without the variant
       // meta data
-      case err: UserIneligibleForAbTest => {
+      case err: UserIneligibleForAbTest =>
         logger.info("user ineligible for AB test, sending regular email", err)
         sendEmailWithCustomFields(emailData, customFields = Map.empty)
-      }
     }
   }
 }

--- a/payment-failure/src/main/scala/com/gu/identity/paymentfailure/IdentityClient.scala
+++ b/payment-failure/src/main/scala/com/gu/identity/paymentfailure/IdentityClient.scala
@@ -74,11 +74,13 @@ object IdentityClient {
 
   @JsonCodec case class ApiError(errors: List[ApiError.Single]) extends IdentityClientError {
     def isInvalidUser: Boolean = errors.exists(_.isInvalidUser)
+    def isUserNotFound: Boolean = errors.exists(_.isUserNotFound)
   }
 
   object ApiError {
     @JsonCodec case class Single(message: String) {
       def isInvalidUser: Boolean = message == "Invalid user"
+      def isUserNotFound: Boolean = message == "User not found"
     }
   }
 

--- a/payment-failure/src/main/scala/com/gu/identity/paymentfailure/abtest/AutoSignInTest.scala
+++ b/payment-failure/src/main/scala/com/gu/identity/paymentfailure/abtest/AutoSignInTest.scala
@@ -14,7 +14,10 @@ class AutoSignInTest(identityClient: IdentityClient) extends VariantGenerator {
       // If the user is invalid for an auto sign-in token,
       // return an UserIneligibleForAbTest,
       // so that the BrazeEmailServiceWithAbTest will send them a regular email
-      case apiError: ApiError if apiError.isInvalidUser => UserIneligibleForAbTest("user not eligible for auto sign-in token", Some(apiError))
+      // If user not found, still attempt to send a regular email,
+      // since it might be that the braze external id is a salesforce id instead of an identity id.
+      case apiError: ApiError if apiError.isInvalidUser || apiError.isUserNotFound =>
+        UserIneligibleForAbTest("user not eligible for auto sign-in token", Some(apiError))
       // Otherwise return a RuntimeException
       // The BrazeEmailServiceWithAbTest will propagate this error,
       // meaning the lambda will be invoked again


### PR DESCRIPTION
Failing to handle this caused the dead-letter queue alert. If a user isn't found, send a 'regular' email. See inline comment for justification regarding this error handling.