### PR TITLE
Formstack Consent Lambda

### DIFF
--- a/formstack-consents/.gitignore
+++ b/formstack-consents/.gitignore
@@ -1,0 +1,3 @@
+**/target/
+project/project/
+Newsletter.scala

--- a/formstack-consents/.gitignore
+++ b/formstack-consents/.gitignore
@@ -1,3 +1,2 @@
 **/target/
 project/project/
-Newsletter.scala

--- a/formstack-consents/README.md
+++ b/formstack-consents/README.md
@@ -1,0 +1,5 @@
+# Formstack Consents Lambda
+
+This lambda is responsible for making calls to Formstack, getting the email address of each user who has signed up to newsletters via Formstack and making a subsequent POST request to Identity API /consent-email with the user's email address and the newsletter they signed up to. This will then trigger a confirmation email for that user. 
+
+When the user clicks the link in the email, an identity account will be created for them and they will be signed up to the newsletter. 

--- a/formstack-consents/build.sbt
+++ b/formstack-consents/build.sbt
@@ -1,0 +1,26 @@
+name := "formstack-consents"
+
+version := "0.1"
+
+scalaVersion := "2.12.8"
+val circeVersion = "0.11.0"
+
+libraryDependencies ++= Seq(
+  "com.typesafe.scala-logging" %% "scala-logging" % "3.9.0",
+  "org.typelevel" %% "cats-core" % "2.0.0-M1",
+  "org.scalaj" %% "scalaj-http" % "2.3.0",
+  "io.circe" %% "circe-core" % circeVersion,
+  "io.circe" %% "circe-generic" % circeVersion,
+  "io.circe" %% "circe-parser" % circeVersion,
+  "io.circe" %% "circe-generic-extras" % circeVersion,
+  "com.typesafe" % "config" % "1.3.3",
+  "joda-time" % "joda-time" % "2.3",
+  "org.joda" % "joda-convert" % "1.6",
+  "org.jlib" % "jlib-awslambda-logback" % "1.0.0"
+)
+
+scalacOptions += "-Ypartial-unification"
+
+addCompilerPlugin(
+  "org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full
+)

--- a/formstack-consents/build.sbt
+++ b/formstack-consents/build.sbt
@@ -16,6 +16,7 @@ libraryDependencies ++= Seq(
   "com.typesafe" % "config" % "1.3.3",
   "joda-time" % "joda-time" % "2.3",
   "org.joda" % "joda-convert" % "1.6",
+  "org.typelevel" %% "cats-core" % "2.0.0-M1",
   "org.jlib" % "jlib-awslambda-logback" % "1.0.0"
 )
 

--- a/formstack-consents/project/build.properties
+++ b/formstack-consents/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version = 1.2.8

--- a/formstack-consents/src/main/resources/application.conf
+++ b/formstack-consents/src/main/resources/application.conf
@@ -1,0 +1,1 @@
+include file("/etc/gu/formstack-consents.conf")

--- a/formstack-consents/src/main/resources/logback.xml
+++ b/formstack-consents/src/main/resources/logback.xml
@@ -1,0 +1,13 @@
+<configuration>
+    <contextName>formstack-consents</contextName>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <Pattern>%date [%thread] %-5level %logger{36}:%line - %msg%n%xException{full}</Pattern>
+        </layout>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/formstack-consents/src/main/scala/com/gu/identity/formstackconsents/FormstackClient.scala
+++ b/formstack-consents/src/main/scala/com/gu/identity/formstackconsents/FormstackClient.scala
@@ -56,9 +56,7 @@ class FormstackClient(config: DevConfig) extends StrictLogging {
 }
 
 object FormstackClient {
-  implicit val config: Configuration = Configuration.default
-  // Scala won't allow 'type' as an argument so specifying it used @JsonKey
-  @ConfiguredJsonCodec case class FormstackConsent(field: String, label: String, @JsonKey("type") consentType: String, value: String)
+  @JsonCodec case class FormstackConsent(field: String, label: String, `type`: String, value: String)
   @JsonCodec case class FormstackSubmission(data: Map[String, FormstackConsent])
   @JsonCodec case class FormstackResponse(submissions: List[FormstackSubmission], pages: Int)
 }

--- a/formstack-consents/src/main/scala/com/gu/identity/formstackconsents/FormstackClient.scala
+++ b/formstack-consents/src/main/scala/com/gu/identity/formstackconsents/FormstackClient.scala
@@ -1,0 +1,65 @@
+package com.gu.identity.formstackconsents
+
+import com.gu.identity.globalConfig.DevConfig
+import cats.syntax.either._
+import com.gu.identity.formstackconsents.FormstackClient.FormstackResponse
+import com.typesafe.scalalogging.StrictLogging
+import io.circe.parser.decode
+import scalaj.http.Http
+import io.circe.generic.JsonCodec
+import io.circe.generic.extras.{Configuration, ConfiguredJsonCodec, JsonKey}
+import org.joda.time.DateTime
+
+class FormstackClient(config: DevConfig) extends StrictLogging {
+
+  def requestForMultiplePages(res: FormstackResponse, newsletter: Newsletter): List[FormstackResponse] = {
+    val pagesList = (2 to res.pages).toList
+    pagesList.foldLeft(List(res)){ (acc, page) => {
+      getSubmissionsForGivenPage(newsletter.formId, page) match {
+        case Left(_) => List(res)
+        case Right(response) => response :: acc
+      }
+    }}
+  }
+
+  def getSubmissionsForGivenPage(newsletterId: String, page: Int): Either[Throwable, FormstackResponse] = {
+    val request = Http(s"${config.Formstack.host}/api/v2/form/$newsletterId/submission.json")
+      .header("Authorization", config.Formstack.token)
+      .params(Seq(
+        ("status", "attending"),
+        ("page", page.toString),
+        // TODO: how to manage this so that it is from the last time it ran?
+        ("min_time", DateTime.now.minusDays(1).toString()),
+        // Formstack api only allows 25 at a time
+        ("per_page", "25"),
+        ("encryption_password", config.Formstack.password),
+        ("data", "1")
+      ))
+
+    Either.catchNonFatal(request.asString)
+      .flatMap {
+        case res if res.is2xx => decode[FormstackResponse](res.body)
+        case res =>
+          val errorMessage = s"unable to get submissions for newsletter $newsletterId page ${page.toString}"
+          logger.error(errorMessage)
+          Left(new Throwable(s"$errorMessage: ${res.body}"))
+      }
+  }
+
+  def getConsentsForNewsletter(newsletter: Newsletter): Either[Throwable, List[FormstackResponse]] = {
+    val request = getSubmissionsForGivenPage(newsletter.formId, page = 1)
+    request.flatMap(res => res.pages match {
+      case 1 => Right(List(res))
+      case _ => Right(requestForMultiplePages(res, newsletter))
+    })
+  }
+}
+
+object FormstackClient {
+  implicit val config: Configuration = Configuration.default
+  // Scala won't allow 'type' as an argument so specifying it used @JsonKey
+  @ConfiguredJsonCodec case class FormstackConsent(field: String, label: String, @JsonKey("type") consentType: String, value: String)
+  @JsonCodec case class FormstackSubmission(data: Map[String, FormstackConsent])
+  @JsonCodec case class FormstackResponse(submissions: List[FormstackSubmission], pages: Int)
+}
+

--- a/formstack-consents/src/main/scala/com/gu/identity/formstackconsents/IdentityClient.scala
+++ b/formstack-consents/src/main/scala/com/gu/identity/formstackconsents/IdentityClient.scala
@@ -1,0 +1,49 @@
+package com.gu.identity.formstackconsents
+
+import com.gu.identity.formstackconsents.FormstackClient.FormstackConsent
+import com.gu.identity.globalConfig.DevConfig
+import io.circe.syntax._
+import cats.syntax.either._
+import com.typesafe.scalalogging.StrictLogging
+import io.circe.generic.extras._
+import scalaj.http.Http
+
+class IdentityClient(config: DevConfig) extends StrictLogging {
+  def sendConsentToIdentity(formstackConsent: FormstackConsent, newsletter: Newsletter): Either[Throwable, Unit] = {
+
+    // The key in the JSON sent to Identity depends on the listType. Sometimes the listType is 'set-lists' with a value of the consent name,
+    // and sometimes the listType is 'set-consents'. See example below.
+    //  {
+    //    "email" : "lauren.emms@guardian.co.uk",
+    //    "set-consents" : "holidays"
+    //  }
+
+    implicit val circeConfig: Configuration = Configuration.default.copy(
+      transformMemberNames = {
+        case "listType" => newsletter.listType
+        case other => other
+      }
+    )
+
+    @ConfiguredJsonCodec case class IdentityRequest(email: String, listType: List[String])
+
+    val requestBody = IdentityRequest(formstackConsent.value, List(newsletter.consent))
+
+    val response = Http(s"${config.Identity.host}/consent-email")
+      .headers(("Authorization", config.Identity.accessToken), ("Content-type", "application/json"), ("Accept", "text/plain"))
+      .postData(requestBody.asJson.noSpaces)
+
+    Either.catchNonFatal(response.asString)
+      .leftMap(err => new Throwable(s"Connection to identity failed: $err"))
+      .flatMap {
+        case res if res.is2xx =>
+          Right(logger.info(s"successfully posted newsletter consent to identity: email: ${formstackConsent.value}, newsletter: ${newsletter.consent}"))
+        case res =>
+          val errorMessage = s"unable to post newsletter consent to identity: email: ${formstackConsent.value}, newsletter: ${newsletter.consent}"
+          logger.error(errorMessage)
+          Left(new Throwable(s"$errorMessage: ${res.body}"))
+
+      }
+  }
+}
+

--- a/formstack-consents/src/main/scala/com/gu/identity/formstackconsents/IdentityClient.scala
+++ b/formstack-consents/src/main/scala/com/gu/identity/formstackconsents/IdentityClient.scala
@@ -6,10 +6,10 @@ import io.circe.syntax._
 import cats.syntax.either._
 import com.typesafe.scalalogging.StrictLogging
 import io.circe.generic.extras._
-import scalaj.http.Http
+import scalaj.http.{Http, HttpResponse}
 
 class IdentityClient(config: DevConfig) extends StrictLogging {
-  def sendConsentToIdentity(formstackConsent: FormstackConsent, newsletter: Newsletter): Either[Throwable, Unit] = {
+  def sendConsentToIdentity(formstackConsent: FormstackConsent, newsletter: Newsletter): Either[Throwable, HttpResponse[String]] = {
 
     // The key in the JSON sent to Identity depends on the listType. Sometimes the listType is 'set-lists' with a value of the consent name,
     // and sometimes the listType is 'set-consents'. See example below.
@@ -37,7 +37,8 @@ class IdentityClient(config: DevConfig) extends StrictLogging {
       .leftMap(err => new Throwable(s"Connection to identity failed: $err"))
       .flatMap {
         case res if res.is2xx =>
-          Right(logger.info(s"successfully posted newsletter consent to identity: email: ${formstackConsent.value}, newsletter: ${newsletter.consent}"))
+          logger.info(s"successfully posted newsletter consent to identity: email: ${formstackConsent.value}, newsletter: ${newsletter.consent}")
+          Right(res)
         case res =>
           val errorMessage = s"unable to post newsletter consent to identity: email: ${formstackConsent.value}, newsletter: ${newsletter.consent}"
           logger.error(errorMessage)

--- a/formstack-consents/src/main/scala/com/gu/identity/formstackconsents/Lambda.scala
+++ b/formstack-consents/src/main/scala/com/gu/identity/formstackconsents/Lambda.scala
@@ -1,0 +1,19 @@
+package com.gu.identity.formstackconsents
+
+import com.gu.identity.globalConfig.DevConfig
+
+object Lambda extends App {
+
+  val newsletters: List[Newsletter] = List(Holidays, Students, Universities, Teachers, Masterclasses, SocietyWeekly, EdinburghFestivalDataCollection)
+
+  def handler(): Unit = {
+    // TODO: look into integrating parameter store through cloudformation
+    val config = new DevConfig
+    val formstackClient = new FormstackClient(config)
+    val identityClient = new IdentityClient(config)
+    val lambdaService = new LambdaService(config, formstackClient, identityClient)
+
+    newsletters.map(lambdaService.getConsentsAndSendToIdentity)
+  }
+}
+

--- a/formstack-consents/src/main/scala/com/gu/identity/formstackconsents/LambdaService.scala
+++ b/formstack-consents/src/main/scala/com/gu/identity/formstackconsents/LambdaService.scala
@@ -1,0 +1,33 @@
+package com.gu.identity.formstackconsents
+
+import com.gu.identity.formstackconsents.FormstackClient.FormstackConsent
+import com.gu.identity.globalConfig.DevConfig
+import com.typesafe.scalalogging.StrictLogging
+
+class LambdaService(config: DevConfig, formstackClient: FormstackClient, identityClient: IdentityClient) extends StrictLogging {
+
+  def getEmailConsentFromSubmission(submission: FormstackClient.FormstackSubmission): Either[Throwable, FormstackConsent] = {
+    val emailField = submission.data.find(field => field._2.label.toLowerCase().contains("email address") && field._2.consentType == "email")
+    emailField match {
+      case Some(consent) => Right(consent._2)
+      case None =>
+        val errorMessage = "Unable to find email address field in Formstack submission"
+        logger.error(errorMessage)
+        Left(new Throwable(errorMessage))
+    }
+  }
+
+  def sendConsentToIdentity(consent: FormstackConsent, newsletter: Newsletter): Either[Throwable, Unit] = {
+    identityClient.sendConsentToIdentity(consent, newsletter)
+  }
+
+  def getConsentsAndSendToIdentity(newsletter: Newsletter): Either[Throwable, Unit] = {
+    formstackClient.getConsentsForNewsletter(newsletter) match {
+      case Left(err) => Left(err)
+      case Right(multiplePageResponses) => Right(multiplePageResponses
+        .map(pageResponse => pageResponse.submissions
+          .map(submission => getEmailConsentFromSubmission(submission)
+            .map(email => sendConsentToIdentity(email, newsletter)))))
+    }
+  }
+}

--- a/formstack-consents/src/main/scala/com/gu/identity/formstackconsents/Newsletter.scala
+++ b/formstack-consents/src/main/scala/com/gu/identity/formstackconsents/Newsletter.scala
@@ -4,46 +4,46 @@ sealed trait Newsletter {
   val formId: String
   val listType: String
   val consent: String
+}
 
-  case object Holidays extends Newsletter {
-    val formId = "1945214"
-    val listType = "set-consents"
-    val consent = "holidays"
-  }
+case object Holidays extends Newsletter {
+  val formId = "1945214"
+  val listType = "set-consents"
+  val consent = "holidays"
+}
 
-  case object Students extends Newsletter {
-    val formId = "2946711"
-    val listType = "set-lists"
-    val consent = "guardian-students"
-  }
+case object Students extends Newsletter {
+  val formId = "2946711"
+  val listType = "set-lists"
+  val consent = "guardian-students"
+}
 
-  case object Universities extends Newsletter {
-    val formId = "2946489"
-    val listType = "set-lists"
-    val consent = "higher-education-network"
-  }
+case object Universities extends Newsletter {
+  val formId = "2946489"
+  val listType = "set-lists"
+  val consent = "higher-education-network"
+}
 
-  case object Teachers extends Newsletter {
-    val formId = "2799698"
-    val listType = "set-lists"
-    val consent = "teacher-network"
-  }
+case object Teachers extends Newsletter {
+  val formId = "2799698"
+  val listType = "set-lists"
+  val consent = "teacher-network"
+}
 
-  case object Masterclasses extends Newsletter {
-    val formId = "1898609"
-    val listType = "set-consents"
-    val consent = "events"
-  }
+case object Masterclasses extends Newsletter {
+  val formId = "1898609"
+  val listType = "set-consents"
+  val consent = "events"
+}
 
-  case object SocietyWeekly extends Newsletter {
-    val formId = "3082194"
-    val listType = "set-lists"
-    val consent = "society-weekly"
-  }
+case object SocietyWeekly extends Newsletter {
+  val formId = "3082194"
+  val listType = "set-lists"
+  val consent = "society-weekly"
+}
 
-  case object EdinburghFestivalDataCollection extends Newsletter {
-    val formId = "3163410"
-    val listType = "set-consents"
-    val consent = "supporter"
-  }
+case object EdinburghFestivalDataCollection extends Newsletter {
+  val formId = "3163410"
+  val listType = "set-consents"
+  val consent = "supporter"
 }

--- a/formstack-consents/src/main/scala/com/gu/identity/formstackconsents/Newsletter.scala
+++ b/formstack-consents/src/main/scala/com/gu/identity/formstackconsents/Newsletter.scala
@@ -4,4 +4,48 @@ sealed trait Newsletter {
   val formId: String
   val listType: String
   val consent: String
+
+  // TODO: are these private?
+
+  case object Holidays extends Newsletter {
+    val formId = "1945214"
+    val listType = "set-consents"
+    val consent = "holidays"
+  }
+
+  case object Students extends Newsletter {
+    val formId = "2946711"
+    val listType = "set-lists"
+    val consent = "guardian-students"
+  }
+
+  case object Universities extends Newsletter {
+    val formId = "2946489"
+    val listType = "set-lists"
+    val consent = "higher-education-network"
+  }
+
+  case object Teachers extends Newsletter {
+    val formId = "2799698"
+    val listType = "set-lists"
+    val consent = "teacher-network"
+  }
+
+  case object Masterclasses extends Newsletter {
+    val formId = "1898609"
+    val listType = "set-consents"
+    val consent = "events"
+  }
+
+  case object SocietyWeekly extends Newsletter {
+    val formId = "3082194"
+    val listType = "set-lists"
+    val consent = "society-weekly"
+  }
+
+  case object EdinburghFestivalDataCollection extends Newsletter {
+    val formId = "3163410"
+    val listType = "set-consents"
+    val consent = "supporter"
+  }
 }

--- a/formstack-consents/src/main/scala/com/gu/identity/formstackconsents/Newsletter.scala
+++ b/formstack-consents/src/main/scala/com/gu/identity/formstackconsents/Newsletter.scala
@@ -1,0 +1,7 @@
+package com.gu.identity.formstackconsents
+
+sealed trait Newsletter {
+  val formId: String
+  val listType: String
+  val consent: String
+}

--- a/formstack-consents/src/main/scala/com/gu/identity/formstackconsents/Newsletter.scala
+++ b/formstack-consents/src/main/scala/com/gu/identity/formstackconsents/Newsletter.scala
@@ -5,8 +5,6 @@ sealed trait Newsletter {
   val listType: String
   val consent: String
 
-  // TODO: are these private?
-
   case object Holidays extends Newsletter {
     val formId = "1945214"
     val listType = "set-consents"

--- a/formstack-consents/src/main/scala/com/gu/identity/globalConfig/DevConfig.scala
+++ b/formstack-consents/src/main/scala/com/gu/identity/globalConfig/DevConfig.scala
@@ -1,0 +1,25 @@
+package com.gu.identity.globalConfig
+
+import com.typesafe.config.ConfigFactory
+
+class DevConfig {
+
+  // this config will go in parameter store
+
+  private val conf = ConfigFactory.load()
+
+  object Formstack {
+    val token: String = conf.getString("formstack-token")
+    val host: String = conf.getString("formstack-host")
+    val password: String = conf.getString("form-password")
+  }
+
+  object Identity {
+    val accessToken: String = conf.getString("identity-access-token-dev")
+    val prodAccessToken: String = conf.getString("identity-access-token-prod")
+    val host: String = conf.getString("idapi-host-dev")
+    val prodHost: String = conf.getString("idapi-host-prod")
+  }
+}
+
+


### PR DESCRIPTION
There is currently a python script running on a server daily at 10.30am that grabs all Formstack consent submissions and sends the email and consent name to Identity so that we can send users confirmation emails. When they click the link in these emails, we create an Identity account for them and they will be subscribed to that newsletter. 

It was raised to us by the Data Insights team that there was a large difference in the number of users who sign up to receive these newsletters and the number of users who have identity accounts. A small difference is expected as:
1. There is not 100% conversion rate of users who will click the link in the confirmation email (creating an identity account)
2. The conversion rate is made even lower as users will only receive this confirmation email when the script runs, rather than when they fill out the form

However, the difference highlighted by DI was much larger than expected, triggering an investigation into the cause. It was found that the API key used for Formstack had expired and I was given a new one, which was then added to the script. The script successfully ran the following day (sending over 7000 emails as it had not run for 8 weeks).

In order to ensure that we can keep a closer eye on this script in the future, I have created migrated the script to a lambda, which will live in Identity's AWS account.

I will remove DO NOT MERGE label once the following have been added:
- Tests
- Cloudformation and parameter config set up
- Logging