### PR TITLE
move to default Braze service

### DIFF
--- a/payment-failure/src/main/scala/com/gu/identity/paymentfailure/Lambda.scala
+++ b/payment-failure/src/main/scala/com/gu/identity/paymentfailure/Lambda.scala
@@ -59,11 +59,7 @@ object Lambda extends StrictLogging {
       throw err
     }
 
-    // Currently running the auto sign in test
-    // TODO: switch back to using DefaultBrazeEmailService when auto sign in token test is finished
-    val identityClient = new IdentityClient(config)
-    val autoSignInTokenTest = new AutoSignInTest(identityClient)
-    val lambdaService = LambdaService.withAbTest(config, autoSignInTokenTest)
+    val lambdaService = LambdaService.default(config)
 
     logger.info("config and services successfully initialised - processing events")
     lambdaService.processEvent(event)

--- a/payment-failure/src/main/scala/com/gu/identity/paymentfailure/LambdaService.scala
+++ b/payment-failure/src/main/scala/com/gu/identity/paymentfailure/LambdaService.scala
@@ -35,10 +35,9 @@ class LambdaService(sqsService: SqsService, brazeEmailService: BrazeEmailService
 object LambdaService {
 
   def default(config: Config): LambdaService = {
-    val identityClient = new IdentityClient(config)
     val sqsService = new SqsService(config)
     val brazeClient = new BrazeClient(config)
-    val sendEmailService = new DefaultBrazeEmailService(identityClient, brazeClient, config)
+    val sendEmailService = new DefaultBrazeEmailService(brazeClient, config)
     new LambdaService(sqsService, sendEmailService)
   }
 

--- a/payment-failure/src/test/scala/com/gu/identity/paymentfailure/BrazeEmailServiceTest.scala
+++ b/payment-failure/src/test/scala/com/gu/identity/paymentfailure/BrazeEmailServiceTest.scala
@@ -1,6 +1,5 @@
 package com.gu.identity.paymentfailure
 
-import com.gu.identity.paymentfailure.IdentityClient._
 import com.gu.identity.paymentfailure.abtest.{AutoSignInTest, Variant, VariantGenerator}
 import org.scalatest.{Matchers, WordSpec}
 import org.scalatest.mockito.MockitoSugar
@@ -11,166 +10,38 @@ class DefaultBrazeEmailServiceTest extends WordSpec with Matchers with MockitoSu
 
   trait TestFixture {
     val config = mock[Config]
-    val identityClient = mock[IdentityClient]
     val brazeClient = mock[BrazeClient]
-    val sendEmailService = new DefaultBrazeEmailService(identityClient, brazeClient, config)
+    val sendEmailService = new DefaultBrazeEmailService(brazeClient, config)
 
     when(config.brazeApiKey).thenReturn("braze-api-key")
   }
 
-  "The DefaultBrazeEmailService" when {
+  "The DefaultBrazeEmailService" should {
 
-    "it is used to send an email with auto sign-in and email tokens" should {
+    "send an email to Braze" in new TestFixture {
 
-      "send the email with both tokens if they have both been created" in new TestFixture {
-
-        when(identityClient.createAutoSignInToken(any[AutoSignInLinkRequestBody]))
-          .thenReturn(Right(AutoSignInLinkResponseBody("auto-signin-token")))
-
-        when(identityClient.encryptEmail(any[IdentityEmailTokenRequest]))
-            .thenReturn(Right(IdentityEmailTokenResponse("ok", "email-token")))
-
-        sendEmailService.sendEmail(
-          IdentityBrazeEmailData(
-            externalId = "identity-id",
-            emailAddress = "email",
-            templateId = "template-id",
-            customFields = Map("name" -> "test-user")
-          )
+      sendEmailService.sendEmail(
+        IdentityBrazeEmailData(
+          externalId = "identity-id",
+          emailAddress = "email",
+          templateId = "template-id",
+          customFields = Map("name" -> "test-user")
         )
+      )
 
-        verify(identityClient, times(1))
-          .createAutoSignInToken(AutoSignInLinkRequestBody("identity-id", "email"))
-
-        verify(brazeClient, times(1))
-          .sendEmail(
-            BrazeSendRequest(
-              api_key = "braze-api-key",
-              campaign_id = "template-id",
-              recipients = List(
-                BrazeRecipient(
-                  external_user_id = "identity-id",
-                  trigger_properties = Map(
-                    "name" -> "test-user",
-                    "autoSignInToken" -> "auto-signin-token",
-                    "emailToken" -> "email-token"
-                  )
-                )
+      verify(brazeClient, times(1))
+        .sendEmail(
+          BrazeSendRequest(
+            api_key = "braze-api-key",
+            campaign_id = "template-id",
+            recipients = List(
+              BrazeRecipient(
+                external_user_id = "identity-id",
+                trigger_properties = Map("name" -> "test-user")
               )
             )
           )
-      }
-
-      "still send them email with the auto sign-in token if the email token hasn't been created" in new TestFixture {
-
-        when(identityClient.createAutoSignInToken(any[AutoSignInLinkRequestBody]))
-          .thenReturn(Right(AutoSignInLinkResponseBody("auto-signin-token")))
-
-        when(identityClient.encryptEmail(any[IdentityEmailTokenRequest]))
-          .thenReturn(Left(IdentityClientError.fromThrowable(new Throwable)))
-
-        sendEmailService.sendEmail(
-          IdentityBrazeEmailData(
-            externalId = "identity-id",
-            emailAddress = "email",
-            templateId = "template-id",
-            customFields = Map("name" -> "test-user")
-          )
         )
-
-        verify(identityClient, times(1))
-          .createAutoSignInToken(AutoSignInLinkRequestBody("identity-id", "email"))
-
-        verify(brazeClient, times(1))
-          .sendEmail(
-            BrazeSendRequest(
-              api_key = "braze-api-key",
-              campaign_id = "template-id",
-              recipients = List(
-                BrazeRecipient(
-                  external_user_id = "identity-id",
-                  trigger_properties = Map(
-                    "name" -> "test-user",
-                    "autoSignInToken" -> "auto-signin-token"
-                  )
-                )
-              )
-            )
-          )
-      }
-
-      "still send the email with the email token if the auto sign-in token hasn't been created" in new TestFixture {
-
-        when(identityClient.createAutoSignInToken(any[AutoSignInLinkRequestBody]))
-          .thenReturn(Left(IdentityClientError.fromThrowable(new Throwable)))
-
-        when(identityClient.encryptEmail(any[IdentityEmailTokenRequest]))
-          .thenReturn(Right(IdentityEmailTokenResponse("ok", "email-token")))
-
-        sendEmailService.sendEmail(
-          IdentityBrazeEmailData(
-            externalId = "identity-id",
-            emailAddress = "email",
-            templateId = "template-id",
-            customFields = Map("name" -> "test-user")
-          )
-        )
-
-        verify(identityClient, times(1))
-          .createAutoSignInToken(AutoSignInLinkRequestBody("identity-id", "email"))
-
-        verify(brazeClient, times(1))
-          .sendEmail(
-            BrazeSendRequest(
-              api_key = "braze-api-key",
-              campaign_id = "template-id",
-              recipients = List(
-                BrazeRecipient(
-                  external_user_id = "identity-id",
-                  trigger_properties = Map(
-                    "name" -> "test-user",
-                    "emailToken" -> "email-token"
-                  )
-                )
-              )
-            )
-          )
-      }
-
-      "still send the email with no tokens if neither of them were created" in new TestFixture {
-
-        when(identityClient.createAutoSignInToken(any[AutoSignInLinkRequestBody]))
-          .thenReturn(Left(IdentityClientError.fromThrowable(new Throwable)))
-
-        when(identityClient.encryptEmail(any[IdentityEmailTokenRequest]))
-          .thenReturn(Left(IdentityClientError.fromThrowable(new Throwable)))
-
-        sendEmailService.sendEmail(
-          IdentityBrazeEmailData(
-            externalId = "identity-id",
-            emailAddress = "email",
-            templateId = "template-id",
-            customFields = Map("name" -> "test-user")
-          )
-        )
-
-        verify(identityClient, times(1))
-          .createAutoSignInToken(AutoSignInLinkRequestBody("identity-id", "email"))
-
-        verify(brazeClient, times(1))
-          .sendEmail(
-            BrazeSendRequest(
-              api_key = "braze-api-key",
-              campaign_id = "template-id",
-              recipients = List(
-                BrazeRecipient(
-                  external_user_id = "identity-id",
-                  trigger_properties = Map("name" -> "test-user")
-                )
-              )
-            )
-          )
-      }
     }
   }
 }


### PR DESCRIPTION
There was an upstream change in membership workflow which has changed the type of external id. Reverting to the default service and deferring thinking through / addressing the implication of this till tomorrow.

Doing this will stop the auto sign-in AB test.