### PR TITLE
New serialisation format for event messages

### DIFF
--- a/payment-failure/build.sbt
+++ b/payment-failure/build.sbt
@@ -11,6 +11,8 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.0",
   "com.amazonaws" % "aws-lambda-java-events" % "2.2.2",
   "com.amazonaws" % "aws-java-sdk-sqs" % "1.11.472",
+  "com.beachape" %% "enumeratum" % "1.5.13",
+  "com.beachape" %% "enumeratum-circe" % "1.5.21",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.0",
   "io.circe" %% "circe-core" % circeVersion,
   "io.circe" %% "circe-parser" % circeVersion,

--- a/payment-failure/src/main/scala/com/gu/identity/paymentfailure/BrazeEmailService.scala
+++ b/payment-failure/src/main/scala/com/gu/identity/paymentfailure/BrazeEmailService.scala
@@ -21,7 +21,7 @@ object BrazeEmailService {
     emailData: IdentityBrazeEmailData,
     customFields: Map[String, String]
   ): BrazeSendRequest = {
-    val recipient = BrazeRecipient(emailData.externalId, emailData.customFields ++ customFields)
+    val recipient = BrazeRecipient(emailData.externalId.value, emailData.customFields ++ customFields)
     BrazeSendRequest(brazeApiKey, emailData.templateId, List(recipient))
   }
 }
@@ -62,7 +62,7 @@ class DefaultBrazeEmailService(
 
   def sendEmail(emailData: IdentityBrazeEmailData): Either[Throwable, BrazeResponse] = {
     val encryptedEmailToken = encryptEmail(emailData.emailAddress)
-    val autoSignInToken = createAutoSignInToken(emailData.externalId, emailData.emailAddress)
+    val autoSignInToken = createAutoSignInToken(emailData.externalId.value, emailData.emailAddress)
     val tokenFields = List(
       encryptedEmailToken.map(TriggerProperties.emailToken -> _),
       autoSignInToken.map(TriggerProperties.autoSignInToken -> _)
@@ -91,7 +91,7 @@ class BrazeEmailServiceWithAbTest(
   def sendEmail(emailData: IdentityBrazeEmailData): Either[Throwable, BrazeResponse] = {
     logger.info(s"attempting to send email for test ${variantGenerator.abTest}")
     (for {
-      variant <- variantGenerator.generateVariant(emailData.externalId, emailData.emailAddress)
+      variant <- variantGenerator.generateVariant(emailData.externalId.value, emailData.emailAddress)
       customFields = variantToCustomFields(variant)
       response <- sendEmailWithCustomFields(emailData, customFields)
     } yield {

--- a/payment-failure/src/main/scala/com/gu/identity/paymentfailure/LambdaService.scala
+++ b/payment-failure/src/main/scala/com/gu/identity/paymentfailure/LambdaService.scala
@@ -14,7 +14,7 @@ class LambdaService(sqsService: SqsService, brazeEmailService: BrazeEmailService
 
   def processMessage(message: SQSMessage): Either[Throwable, BrazeResponse] =
     for {
-      emailData <- sqsService.parseSingleMessage(message)
+      emailData <- sqsService.parseMessage[IdentityBrazeEmailData](message)
       brazeResponse <- brazeEmailService.sendEmail(emailData)
       // Deleting a message from the queue will mean that even if the lambda throws an error
       // to signify that not all messages in the event have been processed successfully,

--- a/payment-failure/src/main/scala/com/gu/identity/paymentfailure/Model.scala
+++ b/payment-failure/src/main/scala/com/gu/identity/paymentfailure/Model.scala
@@ -1,11 +1,41 @@
 package com.gu.identity.paymentfailure
 
+import enumeratum.{CirceEnum, EnumEntry}
 import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
 import io.circe.{Decoder, Encoder}
 
+import scala.collection.immutable
+
 case class Config(idapiHost: String, brazeApiHost: String, idapiAccessToken: String, queueURL: String, brazeApiKey: String)
 
-case class IdentityBrazeEmailData(externalId: String, emailAddress: String, templateId: String, customFields: Map[String, String])
+sealed trait BrazeExternalIdType extends EnumEntry
+
+object BrazeExternalIdType extends enumeratum.Enum[BrazeExternalIdType] with CirceEnum[BrazeExternalIdType] {
+
+  override val values: immutable.IndexedSeq[BrazeExternalIdType] = findValues
+
+  case object SalesforceId extends BrazeExternalIdType
+  case object IdentityId extends BrazeExternalIdType
+  case object BrazeUuid extends BrazeExternalIdType
+}
+
+case class BrazeExternalId(value: String, externalIdType: BrazeExternalIdType)
+
+object BrazeExternalId {
+
+  implicit val brazeExternalIdDecoder: Decoder[BrazeExternalId] = deriveDecoder[BrazeExternalId]
+
+  def fromSalesforceId(salesforceId: String): BrazeExternalId =
+    BrazeExternalId(salesforceId, externalIdType = BrazeExternalIdType.SalesforceId)
+
+  def fromIdentityId(identityId: String): BrazeExternalId =
+    BrazeExternalId(identityId, externalIdType = BrazeExternalIdType.IdentityId)
+
+  def fromBrazeUuid(brazeUuid: String): BrazeExternalId =
+    BrazeExternalId(brazeUuid, externalIdType = BrazeExternalIdType.BrazeUuid)
+}
+
+case class IdentityBrazeEmailData(externalId: BrazeExternalId, emailAddress: String, templateId: String, customFields: Map[String, String])
 
 object IdentityBrazeEmailData {
   implicit val identityBrazeEmailDataDecoder: Decoder[IdentityBrazeEmailData] = deriveDecoder[IdentityBrazeEmailData]

--- a/payment-failure/src/test/scala/com/gu/identity/paymentfailure/BrazeEmailServiceTest.scala
+++ b/payment-failure/src/test/scala/com/gu/identity/paymentfailure/BrazeEmailServiceTest.scala
@@ -32,7 +32,7 @@ class DefaultBrazeEmailServiceTest extends WordSpec with Matchers with MockitoSu
 
         sendEmailService.sendEmail(
           IdentityBrazeEmailData(
-            externalId = "identity-id",
+            externalId = BrazeExternalId.fromIdentityId(identityId = "identity-id"),
             emailAddress = "email",
             templateId = "template-id",
             customFields = Map("name" -> "test-user")
@@ -71,7 +71,7 @@ class DefaultBrazeEmailServiceTest extends WordSpec with Matchers with MockitoSu
 
         sendEmailService.sendEmail(
           IdentityBrazeEmailData(
-            externalId = "identity-id",
+            externalId = BrazeExternalId.fromIdentityId(identityId = "identity-id"),
             emailAddress = "email",
             templateId = "template-id",
             customFields = Map("name" -> "test-user")
@@ -109,7 +109,7 @@ class DefaultBrazeEmailServiceTest extends WordSpec with Matchers with MockitoSu
 
         sendEmailService.sendEmail(
           IdentityBrazeEmailData(
-            externalId = "identity-id",
+            externalId = BrazeExternalId.fromIdentityId(identityId = "identity-id"),
             emailAddress = "email",
             templateId = "template-id",
             customFields = Map("name" -> "test-user")
@@ -147,7 +147,7 @@ class DefaultBrazeEmailServiceTest extends WordSpec with Matchers with MockitoSu
 
         sendEmailService.sendEmail(
           IdentityBrazeEmailData(
-            externalId = "identity-id",
+            externalId = BrazeExternalId.fromIdentityId(identityId = "identity-id"),
             emailAddress = "email",
             templateId = "template-id",
             customFields = Map("name" -> "test-user")
@@ -212,7 +212,7 @@ class BrazeEmailServiceWithAbTestTest extends WordSpec with Matchers with Mockit
 
         sendEmailService.sendEmail(
           IdentityBrazeEmailData(
-            externalId = "identity-id",
+            externalId = BrazeExternalId.fromIdentityId(identityId = "identity-id"),
             emailAddress = "email",
             templateId = "template-id",
             customFields = Map.empty

--- a/payment-failure/src/test/scala/com/gu/identity/paymentfailure/BrazeExternalIdTest.scala
+++ b/payment-failure/src/test/scala/com/gu/identity/paymentfailure/BrazeExternalIdTest.scala
@@ -1,0 +1,31 @@
+package com.gu.identity.paymentfailure
+
+import io.circe.parser.decode
+import org.scalatest.{EitherValues, Matchers, WordSpecLike}
+
+class BrazeExternalIdTest extends WordSpecLike with Matchers with EitherValues {
+
+  "BrazeExternalId" when {
+
+    "encoded as JSON" should {
+
+      "be successfully de-serialised if the Braze external id is of type salesforce id" in {
+
+        val json = """{"value":"id","externalIdType":"SalesforceId"}"""
+        decode[BrazeExternalId](json).right.value shouldEqual BrazeExternalId.fromSalesforceId("id")
+      }
+
+      "be successfully de-serialised if the Braze external id is of type identity id" in {
+
+        val json = """{"value":"id","externalIdType":"IdentityId"}"""
+        decode[BrazeExternalId](json).right.value shouldEqual BrazeExternalId.fromIdentityId("id")
+      }
+
+      "be successfully de-serialised if the Braze external id is of type Braze uuid" in {
+
+        val json = """{"value":"id","externalIdType":"BrazeUuid"}"""
+        decode[BrazeExternalId](json).right.value shouldEqual BrazeExternalId.fromBrazeUuid("id")
+      }
+    }
+  }
+}

--- a/payment-failure/src/test/scala/com/gu/identity/paymentfailure/LambdaServiceTest.scala
+++ b/payment-failure/src/test/scala/com/gu/identity/paymentfailure/LambdaServiceTest.scala
@@ -22,7 +22,7 @@ class LambdaServiceTest extends WordSpec with Matchers with MockitoSugar with Ei
   val message = mock[SQSMessage]
 
   val emailData = mock[IdentityBrazeEmailData]
-  when(sqsService.parseSingleMessage(message)).thenReturn(Right(emailData))
+  when(sqsService.parseMessage[IdentityBrazeEmailData](message)).thenReturn(Right(emailData))
 
   val brazeResponse = mock[BrazeResponse]
   when(sendEmailService.sendEmail(emailData)).thenReturn(Right(brazeResponse))
@@ -37,7 +37,7 @@ class LambdaServiceTest extends WordSpec with Matchers with MockitoSugar with Ei
   val invalidMessage = mock[SQSMessage]
 
   val parseError = mock[Throwable]
-  when(sqsService.parseSingleMessage(invalidMessage)).thenReturn(Left(parseError))
+  when(sqsService.parseMessage[IdentityBrazeEmailData](invalidMessage)).thenReturn(Left(parseError))
 
   "A Lambda service" when {
 

--- a/payment-failure/src/test/scala/com/gu/identity/paymentfailure/SqsServiceTest.scala
+++ b/payment-failure/src/test/scala/com/gu/identity/paymentfailure/SqsServiceTest.scala
@@ -21,10 +21,18 @@ class SqsServiceTest extends WordSpec with Matchers with MockitoSugar {
         """
           |{
           |   "Type": "Notification",
-          |   "Message" : "{\"externalId\":\"100001111\",\"emailAddress\":\"test@theguardian.com\",\"templateId\":\"6ec82e61-b8b0-4d11-8e5f-9914c0700f38\",\"customFields\":{\"first_name\":\"test-user-first-name\"}}"
+          |   "Message" : "{\"externalId\":{\"value\":\"100001111\",\"externalIdType\":\"IdentityId\"},\"emailAddress\":\"test@theguardian.com\",\"templateId\":\"6ec82e61-b8b0-4d11-8e5f-9914c0700f38\",\"customFields\":{\"first_name\":\"test-user-first-name\"}}"
           |}
         """.stripMargin)
-      sqsService.parseMessage[IdentityBrazeEmailData](sqsMessage) shouldBe Right(IdentityBrazeEmailData("100001111", "test@theguardian.com", "6ec82e61-b8b0-4d11-8e5f-9914c0700f38", Map("first_name" -> "test-user-first-name")))
+      sqsService.parseMessage[IdentityBrazeEmailData](sqsMessage) shouldBe
+        Right(
+          IdentityBrazeEmailData(
+            externalId = BrazeExternalId.fromIdentityId(identityId = "100001111"),
+            emailAddress = "test@theguardian.com",
+            templateId = "6ec82e61-b8b0-4d11-8e5f-9914c0700f38",
+            Map("first_name" -> "test-user-first-name")
+          )
+        )
     }
 
     "throw a decoder error when invalid json is passed in message body" in new TestFixture {

--- a/payment-failure/src/test/scala/com/gu/identity/paymentfailure/SqsServiceTest.scala
+++ b/payment-failure/src/test/scala/com/gu/identity/paymentfailure/SqsServiceTest.scala
@@ -24,7 +24,7 @@ class SqsServiceTest extends WordSpec with Matchers with MockitoSugar {
           |   "Message" : "{\"externalId\":\"100001111\",\"emailAddress\":\"test@theguardian.com\",\"templateId\":\"6ec82e61-b8b0-4d11-8e5f-9914c0700f38\",\"customFields\":{\"first_name\":\"test-user-first-name\"}}"
           |}
         """.stripMargin)
-      sqsService.parseSingleMessage(sqsMessage) shouldBe Right(IdentityBrazeEmailData("100001111", "test@theguardian.com", "6ec82e61-b8b0-4d11-8e5f-9914c0700f38", Map("first_name" -> "test-user-first-name")))
+      sqsService.parseMessage[IdentityBrazeEmailData](sqsMessage) shouldBe Right(IdentityBrazeEmailData("100001111", "test@theguardian.com", "6ec82e61-b8b0-4d11-8e5f-9914c0700f38", Map("first_name" -> "test-user-first-name")))
     }
 
     "throw a decoder error when invalid json is passed in message body" in new TestFixture {
@@ -36,7 +36,7 @@ class SqsServiceTest extends WordSpec with Matchers with MockitoSugar {
           |}
         """.stripMargin
       )
-      sqsService.parseSingleMessage(sqsMessage) shouldBe Left(DecodingFailure("Attempt to decode value on failed cursor", List(DownField("Message"))))
+      sqsService.parseMessage[IdentityBrazeEmailData](sqsMessage) shouldBe Left(DecodingFailure("Attempt to decode value on failed cursor", List(DownField("Message"))))
     }
   }
 }


### PR DESCRIPTION
The event messages in the queue have a new serialisation formation. In particular, the Braze external id which was previously serialised as a string, is now serialised as an object with the following schema:

```
{ 
  "value": string,
  "externalIdType": string
}
```
The new serialisation format will facilitate the lambda creating auto sign-in tokens (c.f. a future PR) - if the external id is of type identity id, a request to create an auto sign-in token will be made; if the external id is of type braze uuid then an initial request will be made to get the corresponding identity id.

This PR updates the lambda to use the new serialisation format.

Related PR: https://github.com/guardian/membership-workflow/pull/190