### PR TITLE
Add Opt In checks to formstack-consent lambda

### DIFF
--- a/formstack-consents/src/main/scala/com/gu/identity/formstackconsents/IdentityClient.scala
+++ b/formstack-consents/src/main/scala/com/gu/identity/formstackconsents/IdentityClient.scala
@@ -13,7 +13,7 @@ import scala.util.Try
 
 class IdentityClient(config: Config) extends StrictLogging {
 
-  val newsletters: List[Newsletter] = List(Holidays, Students, Universities, Teachers, Masterclasses, SocietyWeekly, EdinburghFestivalDataCollection)
+  val newsletters: List[Newsletter] = List(Holidays, Students, Universities, Teachers, Masterclasses, SocietyWeekly, EdinburghFestivalDataCollection, EventMarketingConsentCollection)
 
   def updateConsent(formstackSubmission: FormstackSubmission, newsletter: Newsletter): Option[HttpResponse[String]] = {
 
@@ -45,7 +45,7 @@ class IdentityClient(config: Config) extends StrictLogging {
     val newsletterOpt = newsletters.find(n => n.formId == formstackSubmission.formId)
 
     newsletterOpt.flatMap { newsletter => {
-      val response = updateConsent(formstackSubmission, newsletter)
+      val response = updateConsent(formstackSubmission, newsletter) 
       handleResponseFromIdentity(response, formstackSubmission, newsletter)
     }}
   }

--- a/formstack-consents/src/main/scala/com/gu/identity/formstackconsents/Lambda.scala
+++ b/formstack-consents/src/main/scala/com/gu/identity/formstackconsents/Lambda.scala
@@ -59,6 +59,7 @@ object FormstackSubmission {
   private def getEmailField(cursor: HCursor): Decoder.Result[String] = {
     cursor.downField("email_address").as[String]
       .orElse(cursor.downField("your_email_address").as[String])
+        .orElse(cursor.downField("email").as[String])
   }
 
   implicit val formstackDecoder: Decoder[FormstackSubmission] = new Decoder[FormstackSubmission] {

--- a/formstack-consents/src/main/scala/com/gu/identity/formstackconsents/Newsletter.scala
+++ b/formstack-consents/src/main/scala/com/gu/identity/formstackconsents/Newsletter.scala
@@ -49,13 +49,12 @@ case object EdinburghFestivalDataCollection extends Newsletter {
   val consent = "supporter"
 }
 
-// Marketing Forms requiring opt in check for consent collection.
+// Some marketing Forms have an opt in checkbox for consent collection.
 // Formstack form can be setup with conditional logic to trigger the lambda webhook,
-// but we checked again when the submission is decoded as a precaution.
-// key-value pair must match Formstack submission data.
+// but we want tp check again when the submission is decoded as a precaution.
+// Add new MarketingConsent to newsletters and optInForms values in IdentityClient
 abstract class MarketingConsent extends Newsletter {
-  val optInKey: String
-  val optInValue: String
+  val optInKey: String = "opt_in" //  Request the formstack checkbox hidden label be "opt_in" if possible
 }
 
 case object EventMarketingConsentCollection extends MarketingConsent {
@@ -63,5 +62,4 @@ case object EventMarketingConsentCollection extends MarketingConsent {
   val listType = "set-consents"
   val consent = "supporter"
   override val optInKey: String = "supporter_consent_opt_in"
-  override val optInValue: String = "Opt in"
 }

--- a/formstack-consents/src/main/scala/com/gu/identity/formstackconsents/Newsletter.scala
+++ b/formstack-consents/src/main/scala/com/gu/identity/formstackconsents/Newsletter.scala
@@ -42,8 +42,26 @@ case object SocietyWeekly extends Newsletter {
   val consent = "society-weekly"
 }
 
+// TODO is this form obsolete?
 case object EdinburghFestivalDataCollection extends Newsletter {
   val formId = "3163410"
   val listType = "set-consents"
   val consent = "supporter"
+}
+
+// Marketing Forms requiring opt in check for consent collection.
+// Formstack form can be setup with conditional logic to trigger the lambda webhook,
+// but we checked again when the submission is decoded as a precaution.
+// key-value pair must match Formstack submission data.
+abstract class MarketingConsent extends Newsletter {
+  val optInKey: String
+  val optInValue: String
+}
+
+case object EventMarketingConsentCollection extends MarketingConsent {
+  val formId = "3534972"
+  val listType = "set-consents"
+  val consent = "supporter"
+  override val optInKey: String = "supporter_consent_opt_in"
+  override val optInValue: String = "Opt in"
 }

--- a/formstack-consents/src/test/scala/IdentityClientTest.scala
+++ b/formstack-consents/src/test/scala/IdentityClientTest.scala
@@ -1,12 +1,22 @@
-import com.gu.identity.formstackconsents.{FormstackSubmission, Holidays, IdentityClient, Students}
+import com.gu.identity.formstackconsents._
 import org.scalatest.{Matchers, WordSpec}
 import org.scalatest.mockito.MockitoSugar
 
 class IdentityClientTest extends WordSpec with Matchers with MockitoSugar {
 
+  val config = Lambda.Config("mock", "mock", "mock")
+  val idClient = new IdentityClient(config)
+
   val email = "test@exampledomain.com"
 
-  val formstackSubmission = FormstackSubmission("3082194", "test@exampledomain.com", "secretkey")
+  val formstackSubmission = FormstackSubmission("3082194", "test@exampledomain.com", "secretkey", None)
+
+  val optedInFormstackSubmission = FormstackSubmission("3534972", "test@exampledomain.com", "secretkey", Some(true))
+
+  val notOptedInFormstackSubmission = FormstackSubmission("3534972", "test@exampledomain.com", "secretkey", Some(false))
+
+  val faultyFormstackSubmission1 = FormstackSubmission("3082194", "test@exampledomain.com", "secretkey", Some(true)) // no opt in required
+  val faultyFormstackSubmission2 = FormstackSubmission("3534972", "test@exampledomain.com", "secretkey", None) // missing required opt in
 
   val holidayRequestBody = "{\"email\":\"test@exampledomain.com\",\"set-consents\":[\"holidays\"]}"
 
@@ -19,6 +29,24 @@ class IdentityClientTest extends WordSpec with Matchers with MockitoSugar {
 
     "Correctly encode an Identity Request when the newsletter list-type is set-lists" in {
       IdentityClient.createRequestBody(email, Students).shouldEqual(studentsRequestBody)
+    }
+  }
+
+  "IdentityClient.checkHasOptedIn" should {
+    "Return true if an opt in is not required for the form" in {
+      idClient.checkHasOptedIn(formstackSubmission).shouldEqual(true)
+    }
+    "Return true if the formstack submission has correctly opted in" in {
+      idClient.checkHasOptedIn(optedInFormstackSubmission).shouldEqual(true)
+    }
+    "Return false if the formstack submission has not opted in" in {
+      idClient.checkHasOptedIn(notOptedInFormstackSubmission).shouldEqual(false)
+    }
+    "Return false if the newsletter has unexpected opt_in field" in {
+      idClient.checkHasOptedIn(faultyFormstackSubmission1).shouldEqual(false)
+    }
+    "Return false if the formstack submission is missing the opt in field requirement" in {
+      idClient.checkHasOptedIn(faultyFormstackSubmission2).shouldEqual(false)
     }
   }
 }


### PR DESCRIPTION
This change is required by 9/10/19.

# What does this change? 

Adds a `checkHasOptedIn` check to the Lambda's IdentityClient.sendConsentToIdentity control flow to ensure  a consent email is triggered only in the appropriate cases.

### Supporting changes: 
- Adds `MarketingConsent` type for forms that specifically require opt in checks to trigger a consent email from IDAPI
- Updates `FormSubmission` case class to include `opt_in: Option[String]`


# Why is this needed?

Marketing also uses Formstack forms with the option to 'opt in' to additional marketing consents for their campaigns, in this case during a number of summer events.  They wanted to use our existing Professional Networks newsletter signup form integration to collect this marking consent the same day forms are submitted via this existing lambda infrastructure. 

Forms are created and managed by Marketing in Formstack, where a webhook to the lamba is triggered if some one opts in. 

However, as these Formstack settings are not exclusively under our control, with this PR we perform an additional check in the lambda itself to ensure we are never collecting consent and user data inappropriately.

