### PR TITLE
Bump jackson-databind and jackson-annotations to 2.10.1

### DIFF
--- a/payment-failure/build.sbt
+++ b/payment-failure/build.sbt
@@ -23,7 +23,12 @@ libraryDependencies ++= Seq(
   "org.mockito" % "mockito-all" % "1.10.19" % "test",
   "org.scalaj" %% "scalaj-http" % "2.3.0",
   "org.scalactic" %% "scalactic" % "3.0.5",
-  "org.scalatest" %% "scalatest" % "3.0.5" % "test"
+  "org.scalatest" %% "scalatest" % "3.0.5" % "test",
+  
+  // Force a version of jackson-databind that addresses this vulnerability:
+  // https://app.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-469674
+  "com.fasterxml.jackson.core" % "jackson-databind" % "2.10.1",
+  "com.fasterxml.jackson.core" % "jackson-annotations" % "2.10.1",
 )
 
 // Enables the @JsonCodec - https://circe.github.io/circe/


### PR DESCRIPTION
Snyk has reported a vulnerability that requires a jackson-databind bump. See: https://app.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-469674 for more details. 

Note that we are pulling in an old version of jackson-databind and jackson-annotations via the AWS SDK so explicitly pulling in a newer version is the only available approach.

Testing in CODE: 
With master deployed to CODE
- [x] Successfully sent a payment failure email where I could click the link and not have to enter my email address once I landed on manage CODE via https://github.com/guardian/membership-workflow/blob/master/dev/test-payment-failure-email.sh 

With the changes in this PR deployed to CODE
- [x] Successfully sent a payment failure email where I could click the link and not have to enter my email address once I landed on manage CODE via https://github.com/guardian/membership-workflow/blob/master/dev/test-payment-failure-email.sh 