### PR TITLE
Event brite consents sync lambda

### DIFF
--- a/eventbrite-consents/.gitignore
+++ b/eventbrite-consents/.gitignore
@@ -1,0 +1,2 @@
+**/target/
+project/project/

--- a/eventbrite-consents/README.md
+++ b/eventbrite-consents/README.md
@@ -1,10 +1,45 @@
 # Eventbrite consents sync Lambda
 
-Scala lambda which hits the Eventbrite API and finds answers where users have ticked the 'hear more about guardian news and media' check box.
+The service is a Scala lambda which sends emails to users who tick the 'hear more about guardian news and media' check box in Evenbrite.
 
-For positive answers the lambda hits the consent-emails endpoint idapi to trigger a confirmation email.
+## Lambda Details
+
+Eventbrite is a third party service where users can sign up for events. As part of the Eventbrite flow users can click a checkbox labelled
+
+```
+Please tick if you are interested in hearing about these products and services from Guardian News & Media 
+```
+
+The Lambda retrieves a list of emails for users who responded positively to the question from the Eventbrite API. The lambda passes the emails to 
+the `/consent-emails` endpoint on Identity API which triggers confirmation emails for the events consent.
 
 ## Deployments
 
 There is no CODE environment for Eventbrite. For testing we have a DEV Lambda which is configured with `isDebug=true`. This prevents the lambda
-from updating the consents in Identity.
+from updating the consents in Identity. 
+
+## Running Locally
+
+To run the app locally set the environment variables for the app (including API tokens). The parameters used
+in DEV and PROD can be found in the Lambda environment configuration on the AWS console. Be careful, if `isDebug=false` then
+emails could potentially be sent to users if idapiHost and idapiAccessToken are set.
+
+
+Run with SBT
+```
+export idapiHost=not_used_in_debug
+export idapiAccessToken=not_used_in_debug
+export masterclassesToken=set_this
+export eventsToken=set_this
+export syncFrequencyHours=4
+export isDebug=true
+sbt run
+```
+
+or run the com.gu.identity.eventbriteconsents.Lambda.main function with environment variables set in Intellij.
+
+## Unit tests
+
+```
+sbt test
+```

--- a/eventbrite-consents/README.md
+++ b/eventbrite-consents/README.md
@@ -1,0 +1,10 @@
+# Eventbrite consents sync Lambda
+
+Scala lambda which hits the Eventbrite API and finds answers where users have ticked the 'hear more about guardian news and media' check box.
+
+For positive answers the lambda hits the consent-emails endpoint idapi to trigger a confirmation email.
+
+## Deployments
+
+There is no CODE environment for Eventbrite. For testing we have a DEV Lambda which is configured with `isDebug=true`. This prevents the lambda
+from updating the consents in Identity.

--- a/eventbrite-consents/build.sbt
+++ b/eventbrite-consents/build.sbt
@@ -9,15 +9,11 @@ val circeVersion = "0.11.0"
 libraryDependencies ++= Seq(
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.0",
   "com.amazonaws" % "aws-lambda-java-events" % "2.2.2",
-  "org.typelevel" %% "cats-core" % "2.0.0-M1",
   "org.scalaj" %% "scalaj-http" % "2.3.0",
   "io.circe" %% "circe-core" % circeVersion,
   "io.circe" %% "circe-generic" % circeVersion,
   "io.circe" %% "circe-parser" % circeVersion,
   "io.circe" %% "circe-generic-extras" % circeVersion,
-  "com.typesafe" % "config" % "1.3.3",
-  "joda-time" % "joda-time" % "2.3",
-  "org.joda" % "joda-convert" % "1.6",
   "org.jlib" % "jlib-awslambda-logback" % "1.0.0",
   "org.mockito" % "mockito-all" % "1.10.19" % "test",
   "org.scalactic" %% "scalactic" % "3.0.5",
@@ -25,10 +21,6 @@ libraryDependencies ++= Seq(
 )
 
 scalacOptions += "-Ypartial-unification"
-
-addCompilerPlugin(
-  "org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full
-)
 
 assemblyJarName := "main.jar"
 

--- a/eventbrite-consents/build.sbt
+++ b/eventbrite-consents/build.sbt
@@ -1,0 +1,46 @@
+
+name := "eventbrite-consents-lambda"
+
+version := "0.1"
+
+scalaVersion := "2.12.8"
+val circeVersion = "0.11.0"
+
+libraryDependencies ++= Seq(
+  "com.typesafe.scala-logging" %% "scala-logging" % "3.9.0",
+  "com.amazonaws" % "aws-lambda-java-events" % "2.2.2",
+  "org.typelevel" %% "cats-core" % "2.0.0-M1",
+  "org.scalaj" %% "scalaj-http" % "2.3.0",
+  "io.circe" %% "circe-core" % circeVersion,
+  "io.circe" %% "circe-generic" % circeVersion,
+  "io.circe" %% "circe-parser" % circeVersion,
+  "io.circe" %% "circe-generic-extras" % circeVersion,
+  "com.typesafe" % "config" % "1.3.3",
+  "joda-time" % "joda-time" % "2.3",
+  "org.joda" % "joda-convert" % "1.6",
+  "org.jlib" % "jlib-awslambda-logback" % "1.0.0",
+  "org.mockito" % "mockito-all" % "1.10.19" % "test",
+  "org.scalactic" %% "scalactic" % "3.0.5",
+  "org.scalatest" %% "scalatest" % "3.0.5" % "test"
+)
+
+scalacOptions += "-Ypartial-unification"
+
+addCompilerPlugin(
+  "org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full
+)
+
+assemblyJarName := "main.jar"
+
+assemblyMergeStrategy in assembly := {
+  case PathList("module-info.class") => MergeStrategy.discard
+  case x =>
+    val oldStrategy = (assemblyMergeStrategy in assembly).value
+    oldStrategy(x)
+}
+
+enablePlugins(RiffRaffArtifact)
+riffRaffPackageType := assembly.value
+riffRaffUploadArtifactBucket := Option("riffraff-artifact")
+riffRaffUploadManifestBucket := Option("riffraff-builds")
+riffRaffArtifactResources += (file("cloud-formation.yaml") -> "eventbrite-consents-cfn/cloud-formation.yaml")

--- a/eventbrite-consents/cloud-formation.yaml
+++ b/eventbrite-consents/cloud-formation.yaml
@@ -30,6 +30,11 @@ Mappings:
       value: true
     PROD:
       value: false
+  SyncFrequencyMap:
+    values:
+      # syncFrequency needs to match cron
+      cronExpression: "cron(0 0,4,8,12,16,20 * * ? *)"
+      syncFrequencyHours: 4
 
 Resources:
   TopicPagerDutyAlerts:
@@ -53,8 +58,7 @@ Resources:
           idapiAccessToken: !Ref IdapiAccessToken
           masterclassesToken: !Ref MasterclassesToken
           eventsToken: !Ref EventsToken
-          # update the cron expression when updating this
-          syncFrequencyHours: 4
+          syncFrequencyHours: !FindInMap [SyncFrequencyMap, values, syncFrequencyHours]
           isDebug: !FindInMap [IsDebugMap, !Ref Stage, value]
       Handler: com.gu.identity.eventbriteconsents.Lambda::handler
       Runtime: java8
@@ -66,8 +70,7 @@ Resources:
     Type: AWS::Events::Rule
     Properties:
       Description: "ScheduledRule"
-      # update syncFrequencyHours parameter when updating this
-      ScheduleExpression: "cron(0 0,4,8,12,16,20 * * ? *)"
+      ScheduleExpression: !FindInMap [SyncFrequencyMap, values, cronExpression]
       State: "ENABLED"
       Targets:
         - Arn: !GetAtt EventbriteConsentsLambda.Arn

--- a/eventbrite-consents/cloud-formation.yaml
+++ b/eventbrite-consents/cloud-formation.yaml
@@ -5,10 +5,13 @@ Parameters:
   IdapiAccessToken:
     Description: key used to authenticate against the identity API
     Type: String
+    NoEcho: true
   MasterclassesToken:
     Type: String
+    NoEcho: true
   EventsToken:
     Type: String
+    NoEcho: true
   Stage:
     Description: environment name
     Type: String

--- a/eventbrite-consents/cloud-formation.yaml
+++ b/eventbrite-consents/cloud-formation.yaml
@@ -1,0 +1,110 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: 'AWS::Serverless-2016-10-31'
+
+Parameters:
+  Stage:
+    Description: environment name
+    Type: String
+    AllowedValues:
+    - CODE
+    - PROD
+  IdentityApiEndpoint:
+    Description: endpoint for the identity API
+    Type: String
+    AllowedValues:
+    - https://idapi.theguardian.com
+    - https://idapi.code.dev-theguardian.com
+  IdentityAPIKey:
+    Description: key used to authenticate against the identity API
+    Type: String
+  EventbriteSharedSecret:
+    Description: The shared secret is included in the form submission data
+    Type: String
+
+Conditions:
+  IsProd: !Equals
+  - !Ref 'Stage'
+  - PROD
+
+Resources:
+  TopicPagerDutyAlerts:
+    Type: AWS::SNS::Topic
+    Properties:
+      DisplayName: PagerDutyTopic
+      Subscription:
+      - Endpoint: https://events.pagerduty.com/adapter/cloudwatch_sns/v1/96fdc0179acb4c5db3e059d775ea6a9e
+        Protocol: https
+
+  EventbriteConsentsLambda:
+    Type: AWS::Serverless::Function
+    Properties:
+      MemorySize: 512
+      FunctionName: !Sub EventbriteConsentsLambda-${Stage}
+      Timeout: 120
+      Description: Lambda to send email to user who has signed up to a newsletter via Eventbrite
+      Environment:
+        Variables:
+          idapiHost: !Sub ${IdentityApiEndpoint}
+          idapiAccessToken: !Sub ${IdentityAPIKey}
+          eventbriteSharedSecret: !Sub ${EventbriteSharedSecret}
+      Handler: com.gu.identity.eventbriteconsents.Lambda::handler
+      Runtime: java8
+      CodeUri:
+        Bucket: identity-lambda
+        Key: !Sub identity/${Stage}/eventbrite-consents-lambda/main.jar
+    Events:
+      EventbriteConsentApi:
+        Type: Api
+        Properties:
+          RestApiId:
+            Ref: ServlessRestApi
+          Path: /consent
+          Method: POST
+
+  ServerlessRestApi:
+    Type: AWS::Serverless::Api
+    Properties:
+      StageName: !Sub ${Stage}
+      DefinitionBody:
+        swagger: 2.0
+        info:
+          version: '1.0'
+          title:
+            Ref: AWS::StackName
+        paths:
+          /consent:
+            post:
+              x-amazon-apigateway-integration:
+                # The HTTP method used in the integration request. For Lambda function invocations, the value must be POST.
+                httpMethod: POST
+                type: aws_proxy
+                uri:
+                  Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${EventbriteConsentsLambda.Arn}/invocations
+              responses: {}
+
+  EventbriteConsentsLambdaPerms:
+    Type: AWS::Lambda::Permission
+    DependsOn:
+    - EventbriteConsentsLambda
+    - ServerlessRestApi
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !Ref EventbriteConsentsLambda
+      Principal: apigateway.amazonaws.com
+
+  EventbriteConsentsLambdaErrorAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmDescription: Alert when eventbrite consents lambda errors
+      Namespace: AWS/Lambda
+      Dimensions:
+      - Name: FunctionName
+        Value: !Ref 'EventbriteConsentsLambda'
+      MetricName: Errors
+      Statistic: Sum
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Threshold: '1'
+      Period: '60'
+      EvaluationPeriods: '1'
+      AlarmActions:
+      - !If [IsProd, !Ref 'TopicPagerDutyAlerts', !Ref 'AWS::NoValue']

--- a/eventbrite-consents/cloud-formation.yaml
+++ b/eventbrite-consents/cloud-formation.yaml
@@ -9,16 +9,24 @@ Parameters:
     Type: String
   EventsToken:
     Type: String
-  IsDebug:
+  Stage:
+    Description: environment name
     Type: String
     AllowedValues:
-      - true
-      - false
+      - DEV
+      - PROD
 
 Conditions:
-  IsDebug: !Equals
-    - !Ref 'IsDebug'
-    - true
+  IsProd: !Equals
+    - !Ref Stage
+    - PROD
+
+Mappings:
+  IsDebugMap:
+    DEV:
+      value: true
+    PROD:
+      value: false
 
 Resources:
   TopicPagerDutyAlerts:
@@ -44,7 +52,7 @@ Resources:
           eventsToken: !Ref EventsToken
           # update the cron expression when updating this
           syncFrequencyHours: 4
-          isDebug: !Ref IsDebug
+          isDebug: !FindInMap [IsDebugMap, !Ref Stage, value]
       Handler: com.gu.identity.eventbriteconsents.Lambda::handler
       Runtime: java8
       CodeUri:
@@ -85,4 +93,4 @@ Resources:
       Period: '60'
       EvaluationPeriods: '1'
       AlarmActions:
-      - !If [IsDebug, !Ref 'TopicPagerDutyAlerts', !Ref 'AWS::NoValue']
+      - !If [IsProd, !Ref 'TopicPagerDutyAlerts', !Ref 'AWS::NoValue']

--- a/eventbrite-consents/cloud-formation.yaml
+++ b/eventbrite-consents/cloud-formation.yaml
@@ -2,29 +2,23 @@ AWSTemplateFormatVersion: '2010-09-09'
 Transform: 'AWS::Serverless-2016-10-31'
 
 Parameters:
-  Stage:
-    Description: environment name
-    Type: String
-    AllowedValues:
-    - CODE
-    - PROD
-  IdentityApiEndpoint:
-    Description: endpoint for the identity API
-    Type: String
-    AllowedValues:
-    - https://idapi.theguardian.com
-    - https://idapi.code.dev-theguardian.com
-  IdentityAPIKey:
+  IdapiAccessToken:
     Description: key used to authenticate against the identity API
     Type: String
-  EventbriteSharedSecret:
-    Description: The shared secret is included in the form submission data
+  MasterclassesToken:
     Type: String
+  EventsToken:
+    Type: String
+  IsDebug:
+    Type: String
+    AllowedValues:
+      - true
+      - false
 
 Conditions:
-  IsProd: !Equals
-  - !Ref 'Stage'
-  - PROD
+  IsDebug: !Equals
+    - !Ref 'IsDebug'
+    - true
 
 Resources:
   TopicPagerDutyAlerts:
@@ -44,53 +38,37 @@ Resources:
       Description: Lambda to send email to user who has signed up to a newsletter via Eventbrite
       Environment:
         Variables:
-          idapiHost: !Sub ${IdentityApiEndpoint}
-          idapiAccessToken: !Sub ${IdentityAPIKey}
-          eventbriteSharedSecret: !Sub ${EventbriteSharedSecret}
+          idapiHost: "https://idapi.theguardian.com"
+          idapiAccessToken: !Ref IdapiAccessToken
+          masterclassesToken: !Ref MasterclassesToken
+          eventsToken: !Ref EventsToken
+          # update the cron expression when updating this
+          syncFrequencyHours: 4
+          isDebug: !Ref IsDebug
       Handler: com.gu.identity.eventbriteconsents.Lambda::handler
       Runtime: java8
       CodeUri:
         Bucket: identity-lambda
         Key: !Sub identity/${Stage}/eventbrite-consents-lambda/main.jar
-    Events:
-      EventbriteConsentApi:
-        Type: Api
-        Properties:
-          RestApiId:
-            Ref: ServlessRestApi
-          Path: /consent
-          Method: POST
 
-  ServerlessRestApi:
-    Type: AWS::Serverless::Api
+  ScheduledRule:
+    Type: AWS::Events::Rule
     Properties:
-      StageName: !Sub ${Stage}
-      DefinitionBody:
-        swagger: 2.0
-        info:
-          version: '1.0'
-          title:
-            Ref: AWS::StackName
-        paths:
-          /consent:
-            post:
-              x-amazon-apigateway-integration:
-                # The HTTP method used in the integration request. For Lambda function invocations, the value must be POST.
-                httpMethod: POST
-                type: aws_proxy
-                uri:
-                  Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${EventbriteConsentsLambda.Arn}/invocations
-              responses: {}
+      Description: "ScheduledRule"
+      # update syncFrequencyHours parameter when updating this
+      ScheduleExpression: "cron(0 0,4,8,12,16,20 * * ? *)"
+      State: "ENABLED"
+      Targets:
+        - Arn: !GetAtt EventbriteConsentsLambda.Arn
+          Id: "eventbriteconsentslambda"
 
-  EventbriteConsentsLambdaPerms:
+  PermissionForEventsToInvokeLambda:
     Type: AWS::Lambda::Permission
-    DependsOn:
-    - EventbriteConsentsLambda
-    - ServerlessRestApi
     Properties:
-      Action: lambda:InvokeFunction
       FunctionName: !Ref EventbriteConsentsLambda
-      Principal: apigateway.amazonaws.com
+      Action: lambda:InvokeFunction
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt ScheduledRule.Arn
 
   EventbriteConsentsLambdaErrorAlarm:
     Type: AWS::CloudWatch::Alarm
@@ -107,4 +85,4 @@ Resources:
       Period: '60'
       EvaluationPeriods: '1'
       AlarmActions:
-      - !If [IsProd, !Ref 'TopicPagerDutyAlerts', !Ref 'AWS::NoValue']
+      - !If [IsDebug, !Ref 'TopicPagerDutyAlerts', !Ref 'AWS::NoValue']

--- a/eventbrite-consents/project/assembly.sbt
+++ b/eventbrite-consents/project/assembly.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.8")

--- a/eventbrite-consents/project/build.properties
+++ b/eventbrite-consents/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version = 1.2.8

--- a/eventbrite-consents/project/plugins.sbt
+++ b/eventbrite-consents/project/plugins.sbt
@@ -1,0 +1,3 @@
+addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.0.0")
+
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")

--- a/eventbrite-consents/riff-raff.yaml
+++ b/eventbrite-consents/riff-raff.yaml
@@ -1,0 +1,18 @@
+stacks: [identity]
+
+regions: [eu-west-1]
+
+deployments:
+  eventbrite-consents-cfn:
+    type: cloud-formation
+    parameters:
+      templatePath: cloud-formation.yaml
+
+  eventbrite-consents-lambda:
+    type: aws-lambda
+    parameters:
+      bucket: identity-lambda
+      functionNames: [EventbriteConsentsLambda-]
+      fileName: main.jar
+      prefixStack: false
+    dependencies: [eventbrite-consents-cfn]

--- a/eventbrite-consents/riff-raff.yaml
+++ b/eventbrite-consents/riff-raff.yaml
@@ -7,6 +7,8 @@ deployments:
     type: cloud-formation
     parameters:
       templatePath: cloud-formation.yaml
+      cloudFormationStackName: eventbrite-consents-lambda
+      cloudFormationStackByTags: false
 
   eventbrite-consents-lambda:
     type: aws-lambda

--- a/eventbrite-consents/src/main/resources/logback.xml
+++ b/eventbrite-consents/src/main/resources/logback.xml
@@ -1,0 +1,13 @@
+<configuration>
+    <contextName>eventbrite-consents</contextName>
+
+    <appender name="awslambda" class="org.jlib.cloud.aws.lambda.logback.AwsLambdaAppender">
+        <encoder type="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>[%d{yyyy-MM-dd HH:mm:ss.SSS}] &lt;%-36X{AWSRequestId:-request-id-not-set-by-lambda-runtime}&gt; %-5level %logger{100} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="awslambda"/>
+    </root>
+</configuration>

--- a/eventbrite-consents/src/main/scala/com/gu/identity/eventbriteconsents/Lambda.scala
+++ b/eventbrite-consents/src/main/scala/com/gu/identity/eventbriteconsents/Lambda.scala
@@ -1,0 +1,25 @@
+package com.gu.identity.eventbriteconsents
+
+import com.amazonaws.services.lambda.runtime.events.{APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent}
+import com.gu.identity.eventbriteconsents.clients.{EventbriteClient, IdapiClient}
+import com.gu.identity.eventbriteconsents.config.LambdaConfig
+import com.gu.identity.eventbriteconsents.services.ConsentsService
+import com.typesafe.scalalogging.LazyLogging
+
+
+object Lambda extends LazyLogging {
+  val config: LambdaConfig = LambdaConfig.loadFromEnvironment()
+  val eventbriteClient: EventbriteClient = new EventbriteClient
+  val idapiClient: IdapiClient = new IdapiClient(config.idapiHost, config.idapiAccessToken)
+  val consentsService: ConsentsService = new ConsentsService(config, eventbriteClient, idapiClient)
+
+  def handler(event: APIGatewayProxyRequestEvent): APIGatewayProxyResponseEvent = {
+    consentsService.syncConsents()
+    new APIGatewayProxyResponseEvent().withStatusCode(204)
+  }
+
+  def main(args: Array[String]): Unit = {
+    consentsService.syncConsents()
+  }
+}
+

--- a/eventbrite-consents/src/main/scala/com/gu/identity/eventbriteconsents/Lambda.scala
+++ b/eventbrite-consents/src/main/scala/com/gu/identity/eventbriteconsents/Lambda.scala
@@ -1,7 +1,7 @@
 package com.gu.identity.eventbriteconsents
 
 import com.amazonaws.services.lambda.runtime.events.{APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent}
-import com.gu.identity.eventbriteconsents.clients.{EventbriteClient, IdapiClient}
+import com.gu.identity.eventbriteconsents.clients.{EventbriteClient, IdentityClient}
 import com.gu.identity.eventbriteconsents.config.LambdaConfig
 import com.gu.identity.eventbriteconsents.services.ConsentsService
 import com.typesafe.scalalogging.LazyLogging
@@ -10,7 +10,7 @@ import com.typesafe.scalalogging.LazyLogging
 object Lambda extends LazyLogging {
   val config: LambdaConfig = LambdaConfig.loadFromEnvironment()
   val eventbriteClient: EventbriteClient = new EventbriteClient
-  val idapiClient: IdapiClient = new IdapiClient(config.idapiHost, config.idapiAccessToken)
+  val idapiClient: IdentityClient = new IdentityClient(config.idapiHost, config.idapiAccessToken)
   val consentsService: ConsentsService = new ConsentsService(config, eventbriteClient, idapiClient)
 
   def handler(event: APIGatewayProxyRequestEvent): APIGatewayProxyResponseEvent = {

--- a/eventbrite-consents/src/main/scala/com/gu/identity/eventbriteconsents/Lambda.scala
+++ b/eventbrite-consents/src/main/scala/com/gu/identity/eventbriteconsents/Lambda.scala
@@ -13,11 +13,13 @@ object Lambda extends LazyLogging {
   val idapiClient: IdentityClient = new IdentityClient(config.idapiHost, config.idapiAccessToken)
   val consentsService: ConsentsService = new ConsentsService(config, eventbriteClient, idapiClient)
 
+  // Entry point for AWS lambda
   def handler(event: APIGatewayProxyRequestEvent): APIGatewayProxyResponseEvent = {
     consentsService.syncConsents()
     new APIGatewayProxyResponseEvent().withStatusCode(204)
   }
 
+  // main is used for testing the service locally
   def main(args: Array[String]): Unit = {
     consentsService.syncConsents()
   }

--- a/eventbrite-consents/src/main/scala/com/gu/identity/eventbriteconsents/clients/EventbriteClient.scala
+++ b/eventbrite-consents/src/main/scala/com/gu/identity/eventbriteconsents/clients/EventbriteClient.scala
@@ -1,0 +1,40 @@
+package com.gu.identity.eventbriteconsents.clients
+
+import java.time.format.DateTimeFormatter
+import java.time.{Instant, ZoneId}
+
+import com.gu.identity.eventbriteconsents.models.EventbriteResponse
+import io.circe.generic.auto._
+import io.circe.parser._
+import scalaj.http.Http
+
+class EventbriteClient {
+  def findConsents(token: String, lastRun: Instant, continuationToken: String = ""): EventbriteResponse = {
+    val formattedLastRun = DateTimeFormatter
+      .ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'")
+      .withZone(ZoneId.of("UTC"))
+      .format(lastRun)
+
+    val response = Http("https://www.eventbriteapi.com/v3/users/me/owned_event_attendees/")
+      .headers(
+        "Authorization" -> s"Bearer $token",
+        "Accept" -> "application/json"
+      )
+      .params(
+        "status" -> "attending",
+        "changed_since" -> formattedLastRun,
+        "continuation" -> continuationToken
+      )
+      .asString
+
+
+    if (response.code == 200) {
+      parse(response.body).flatMap(_.as[EventbriteResponse]) match {
+        case Right(response) => response
+        case Left(error) => throw new RuntimeException(s"unable to deserialise ${response.body}", error)
+      }
+    } else {
+      throw new RuntimeException(s"unexpected response from eventbrite ${response.code} ${response.body}")
+    }
+  }
+}

--- a/eventbrite-consents/src/main/scala/com/gu/identity/eventbriteconsents/clients/IdapiClient.scala
+++ b/eventbrite-consents/src/main/scala/com/gu/identity/eventbriteconsents/clients/IdapiClient.scala
@@ -1,0 +1,21 @@
+package com.gu.identity.eventbriteconsents.clients
+
+import io.circe.generic.auto._
+import io.circe.syntax._
+import scalaj.http.Http
+
+case class IdapiConsentUpdate(email: String, `set-consents`: Vector[String])
+
+class IdapiClient(idapiUrl: String, idapiAccessToken: String) {
+  def updateEventConsent(emailAddress: String): Unit = {
+    val result = Http(s"$idapiUrl/consent-email")
+      .headers(
+        "X-GU-ID-Client-Access-Token" -> s"Bearer $idapiAccessToken",
+        "Content-type" -> "application/json"
+      )
+      .postData(IdapiConsentUpdate(emailAddress, Vector("events")).asJson.noSpaces)
+      .asString
+
+    if (result.code != 200) throw new RuntimeException(s"Unexpected response from idapi ${result.code} ${result.body}")
+  }
+}

--- a/eventbrite-consents/src/main/scala/com/gu/identity/eventbriteconsents/clients/IdentityClient.scala
+++ b/eventbrite-consents/src/main/scala/com/gu/identity/eventbriteconsents/clients/IdentityClient.scala
@@ -16,6 +16,6 @@ class IdentityClient(idapiUrl: String, idapiAccessToken: String) {
       .postData(IdapiConsentUpdate(emailAddress, Vector("events")).asJson.noSpaces)
       .asString
 
-    if (result.code != 200) throw new RuntimeException(s"Unexpected response from idapi ${result.code} ${result.body}")
+    if (result.code != 200) throw new RuntimeException(s"Unexpected response from idapi when syncing email $emailAddress ${result.code} ${result.body}")
   }
 }

--- a/eventbrite-consents/src/main/scala/com/gu/identity/eventbriteconsents/clients/IdentityClient.scala
+++ b/eventbrite-consents/src/main/scala/com/gu/identity/eventbriteconsents/clients/IdentityClient.scala
@@ -6,7 +6,7 @@ import scalaj.http.Http
 
 case class IdapiConsentUpdate(email: String, `set-consents`: Vector[String])
 
-class IdapiClient(idapiUrl: String, idapiAccessToken: String) {
+class IdentityClient(idapiUrl: String, idapiAccessToken: String) {
   def updateEventConsent(emailAddress: String): Unit = {
     val result = Http(s"$idapiUrl/consent-email")
       .headers(

--- a/eventbrite-consents/src/main/scala/com/gu/identity/eventbriteconsents/config/LambdaConfig.scala
+++ b/eventbrite-consents/src/main/scala/com/gu/identity/eventbriteconsents/config/LambdaConfig.scala
@@ -1,0 +1,21 @@
+package com.gu.identity.eventbriteconsents.config
+
+case class LambdaConfig(
+  idapiHost: String,
+  idapiAccessToken: String,
+  masterclassesToken: String,
+  eventsToken: String,
+  syncFrequencyHours: Int
+)
+
+object LambdaConfig {
+  private def loadConfigVar(name: String) = Option(System.getenv(name)).getOrElse(throw new RuntimeException(s"missing config $name"))
+
+  def loadFromEnvironment(): LambdaConfig = LambdaConfig(
+    idapiHost = loadConfigVar("idapiHost"),
+    idapiAccessToken = loadConfigVar("idapiAccessToken"),
+    masterclassesToken = loadConfigVar("masterclassesToken"),
+    eventsToken = loadConfigVar("eventsToken"),
+    syncFrequencyHours = loadConfigVar("syncFrequencyHours").toInt,
+  )
+}

--- a/eventbrite-consents/src/main/scala/com/gu/identity/eventbriteconsents/config/LambdaConfig.scala
+++ b/eventbrite-consents/src/main/scala/com/gu/identity/eventbriteconsents/config/LambdaConfig.scala
@@ -5,11 +5,12 @@ case class LambdaConfig(
   idapiAccessToken: String,
   masterclassesToken: String,
   eventsToken: String,
-  syncFrequencyHours: Int
+  syncFrequencyHours: Int,
+  isDebug: Boolean,
 )
 
 object LambdaConfig {
-  private def loadConfigVar(name: String) = Option(System.getenv(name)).getOrElse(throw new RuntimeException(s"missing config $name"))
+  private def loadConfigVar(name: String) = Option(System.getenv(name)).filter(_.nonEmpty).getOrElse(throw new RuntimeException(s"missing config $name"))
 
   def loadFromEnvironment(): LambdaConfig = LambdaConfig(
     idapiHost = loadConfigVar("idapiHost"),
@@ -17,5 +18,6 @@ object LambdaConfig {
     masterclassesToken = loadConfigVar("masterclassesToken"),
     eventsToken = loadConfigVar("eventsToken"),
     syncFrequencyHours = loadConfigVar("syncFrequencyHours").toInt,
+    isDebug = loadConfigVar("isDebug").toBoolean,
   )
 }

--- a/eventbrite-consents/src/main/scala/com/gu/identity/eventbriteconsents/models/EventbriteModels.scala
+++ b/eventbrite-consents/src/main/scala/com/gu/identity/eventbriteconsents/models/EventbriteModels.scala
@@ -1,0 +1,31 @@
+package com.gu.identity.eventbriteconsents.models
+
+case class EventbriteAnswer(question: Option[String], answer: Option[String]) {
+  val isEventsAndMasterClassesAnswer: Boolean = {
+    question.exists(_.toLowerCase.matches(EventbriteAnswer.questionRegex)) &&
+      answer.exists(_.toLowerCase.matches(EventbriteAnswer.answerRegex))
+  }
+}
+
+object EventbriteAnswer {
+  val questionRegex = "^please tick if you are interested in hearing about these products and services from guardian news [^ ]+ media:.*"
+  val answerRegex = "^events [^ ]+ masterclasses.*"
+}
+
+case class EventbriteProfile(email: Option[String])
+
+case class EventbriteAttendee(answers: Option[Vector[EventbriteAnswer]], profile: Option[EventbriteProfile]) {
+  val answersList: Vector[EventbriteAnswer] = answers.toVector.flatten
+}
+
+case class EventbritePagination(has_more_items: Boolean, continuation: Option[String]) {
+  val continuationToken: Option[String] = this match {
+    case EventbritePagination(true, Some(cont)) => Some(cont)
+    case _ => None
+  }
+}
+
+case class EventbriteResponse(pagination: EventbritePagination, attendees: Option[Vector[EventbriteAttendee]]) {
+  val attendeesList: Vector[EventbriteAttendee] = attendees.toVector.flatten
+}
+

--- a/eventbrite-consents/src/main/scala/com/gu/identity/eventbriteconsents/services/ConsentsService.scala
+++ b/eventbrite-consents/src/main/scala/com/gu/identity/eventbriteconsents/services/ConsentsService.scala
@@ -3,11 +3,11 @@ package com.gu.identity.eventbriteconsents.services
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 
-import com.gu.identity.eventbriteconsents.clients.{EventbriteClient, IdapiClient}
+import com.gu.identity.eventbriteconsents.clients.{EventbriteClient, IdentityClient}
 import com.gu.identity.eventbriteconsents.config.LambdaConfig
 import com.typesafe.scalalogging.LazyLogging
 
-class ConsentsService(config: LambdaConfig, eventbriteClient: EventbriteClient, identitiyClient: IdapiClient) extends LazyLogging {
+class ConsentsService(config: LambdaConfig, eventbriteClient: EventbriteClient, identitiyClient: IdentityClient) extends LazyLogging {
 
   def syncConsents(): Unit = {
     val lastRun = Instant.now().minus(config.syncFrequencyHours, ChronoUnit.HOURS)
@@ -40,7 +40,7 @@ class ConsentsService(config: LambdaConfig, eventbriteClient: EventbriteClient, 
         Thread.sleep(250)
         findConsentEmails(lastRun, token, continue, accumulated)
       case _ =>
-        accumulated
+        accumulated.map(_.toLowerCase)
     }
   }
 }

--- a/eventbrite-consents/src/main/scala/com/gu/identity/eventbriteconsents/services/ConsentsService.scala
+++ b/eventbrite-consents/src/main/scala/com/gu/identity/eventbriteconsents/services/ConsentsService.scala
@@ -1,0 +1,46 @@
+package com.gu.identity.eventbriteconsents.services
+
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+import com.gu.identity.eventbriteconsents.clients.{EventbriteClient, IdapiClient}
+import com.gu.identity.eventbriteconsents.config.LambdaConfig
+import com.typesafe.scalalogging.LazyLogging
+
+class ConsentsService(config: LambdaConfig, eventbriteClient: EventbriteClient, identitiyClient: IdapiClient) extends LazyLogging {
+
+  def syncConsents(): Unit = {
+    val lastRun = Instant.now().minus(config.syncFrequencyHours, ChronoUnit.HOURS)
+    val emailAddresses = findConsentEmails(lastRun, config.masterclassesToken) ++ findConsentEmails(lastRun, config.eventsToken)
+    for {
+      email <- emailAddresses
+    } yield {
+      identitiyClient.updateEventConsent(email)
+      logger.info(s"Synced $email")
+    }
+  }
+
+
+  @scala.annotation.tailrec
+  private def findConsentEmails(lastRun: Instant, token: String, continuation: String = "", accumulator: Set[String] = Set.empty): Set[String] = {
+    val eventbriteResponse = eventbriteClient.findConsents(token, lastRun, continuation)
+
+    val emailAddresses = for {
+      attendee <- eventbriteResponse.attendeesList
+      answer <- attendee.answersList if answer.isEventsAndMasterClassesAnswer
+      profile <- attendee.profile
+      email <- profile.email
+    } yield email
+
+    val accumulated = accumulator ++ emailAddresses.toSet
+
+    eventbriteResponse.pagination.continuationToken match {
+      case Some(continue) =>
+        // Sleep to avoid rate limiting
+        Thread.sleep(250)
+        findConsentEmails(lastRun, token, continue, accumulated)
+      case _ =>
+        accumulated
+    }
+  }
+}

--- a/eventbrite-consents/src/main/scala/com/gu/identity/eventbriteconsents/services/ConsentsService.scala
+++ b/eventbrite-consents/src/main/scala/com/gu/identity/eventbriteconsents/services/ConsentsService.scala
@@ -12,9 +12,12 @@ class ConsentsService(config: LambdaConfig, eventbriteClient: EventbriteClient, 
   def syncConsents(): Unit = {
     val lastRun = Instant.now().minus(config.syncFrequencyHours, ChronoUnit.HOURS)
     val emailAddresses = findConsentEmails(lastRun, config.masterclassesToken) ++ findConsentEmails(lastRun, config.eventsToken)
+    logger.info(s"Number of email address to sync ${emailAddresses.size}")
     for {
       email <- emailAddresses
-    } yield {
+    } yield if (config.isDebug) {
+        logger.info(s"Debug flag is set, not syncing $email")
+    } else {
       identitiyClient.updateEventConsent(email)
       logger.info(s"Synced $email")
     }

--- a/eventbrite-consents/src/main/scala/com/gu/identity/eventbriteconsents/services/ConsentsService.scala
+++ b/eventbrite-consents/src/main/scala/com/gu/identity/eventbriteconsents/services/ConsentsService.scala
@@ -12,7 +12,7 @@ class ConsentsService(config: LambdaConfig, eventbriteClient: EventbriteClient, 
   def syncConsents(): Unit = {
     val lastRun = Instant.now().minus(config.syncFrequencyHours, ChronoUnit.HOURS)
     val emailAddresses = findConsentEmails(lastRun, config.masterclassesToken) ++ findConsentEmails(lastRun, config.eventsToken)
-    logger.info(s"Number of email address to sync ${emailAddresses.size}")
+    logger.info(s"Email addresses to sync $emailAddresses, total ${emailAddresses.size}, last run $lastRun")
     for {
       email <- emailAddresses
     } yield if (config.isDebug) {

--- a/eventbrite-consents/src/test/scala/com/gu/identity/eventbriteconsents/services/ConsentsServiceTest.scala
+++ b/eventbrite-consents/src/test/scala/com/gu/identity/eventbriteconsents/services/ConsentsServiceTest.scala
@@ -53,6 +53,7 @@ class ConsentsServiceTest extends FlatSpec with MockitoSugar {
     when(config.idapiAccessToken) thenReturn "idapiAccessToken"
     when(config.idapiHost) thenReturn "idapiHost"
     when(config.syncFrequencyHours) thenReturn 2
+    when(config.isDebug) thenReturn false
 
 
     when(eventbriteClient.findConsents(eql("masterclassesToken"), any[Instant], eql(""))) thenReturn
@@ -84,6 +85,7 @@ class ConsentsServiceTest extends FlatSpec with MockitoSugar {
     when(config.idapiAccessToken) thenReturn "idapiAccessToken"
     when(config.idapiHost) thenReturn "idapiHost"
     when(config.syncFrequencyHours) thenReturn 2
+    when(config.isDebug) thenReturn false
 
 
     when(eventbriteClient.findConsents(eql("masterclassesToken"), any[Instant], eql(""))) thenReturn
@@ -98,6 +100,36 @@ class ConsentsServiceTest extends FlatSpec with MockitoSugar {
 
     consentsService.syncConsents()
     verifyNoMoreInteractions(identityClient)
+  }
+
+
+
+  "syncConsents" should "not update consents when debug flag is set to true" in {
+    val fixtures = createFixtures()
+    import fixtures._
+
+    when(config.eventsToken) thenReturn "eventsToken"
+    when(config.masterclassesToken) thenReturn "masterclassesToken"
+    when(config.idapiAccessToken) thenReturn "idapiAccessToken"
+    when(config.idapiHost) thenReturn "idapiHost"
+    when(config.syncFrequencyHours) thenReturn 2
+    when(config.isDebug) thenReturn true
+
+
+    when(eventbriteClient.findConsents(eql("masterclassesToken"), any[Instant], eql(""))) thenReturn
+      EventbriteResponse(EventbritePagination(has_more_items = true, continuation = Some("cont1")), Some(Vector(createAttendee("email1@email.com"), createAttendee("email2@email.com"))))
+
+    when(eventbriteClient.findConsents(eql("masterclassesToken"), any[Instant], eql("cont1"))) thenReturn
+      EventbriteResponse(EventbritePagination(has_more_items = false, continuation = None), Some(Vector(notAttending2, createAttendee("email3@email.com"))))
+
+    when(eventbriteClient.findConsents(eql("eventsToken"), any[Instant], eql(""))) thenReturn
+      EventbriteResponse(EventbritePagination(has_more_items = true, continuation = Some("cont2")), Some(Vector(notAttending1, notAttending2)))
+
+    when(eventbriteClient.findConsents(eql("eventsToken"), any[Instant], eql("cont2"))) thenReturn
+      EventbriteResponse(EventbritePagination(has_more_items = false, continuation = None), Some(Vector(createAttendee("email4@email.com"))))
+
+    consentsService.syncConsents()
+    verifyZeroInteractions(identityClient)
   }
 
 }

--- a/eventbrite-consents/src/test/scala/com/gu/identity/eventbriteconsents/services/ConsentsServiceTest.scala
+++ b/eventbrite-consents/src/test/scala/com/gu/identity/eventbriteconsents/services/ConsentsServiceTest.scala
@@ -1,0 +1,103 @@
+package com.gu.identity.eventbriteconsents.services
+
+import java.time.Instant
+
+import com.gu.identity.eventbriteconsents.clients.{EventbriteClient, IdentityClient}
+import com.gu.identity.eventbriteconsents.config.LambdaConfig
+import com.gu.identity.eventbriteconsents.models.{EventbriteAnswer, EventbriteAttendee, EventbritePagination, EventbriteProfile, EventbriteResponse}
+import org.scalatest.FlatSpec
+import org.scalatest.mockito.MockitoSugar
+import org.mockito.Mockito._
+import org.mockito.Matchers._
+import org.mockito.Matchers.{eq => eql}
+
+class ConsentsServiceTest extends FlatSpec with MockitoSugar {
+  def createFixtures() = new {
+    val config = mock[LambdaConfig]
+    val eventbriteClient = mock[EventbriteClient]
+    val identityClient = mock[IdentityClient]
+    val consentsService = new ConsentsService(config, eventbriteClient, identityClient)
+  }
+
+  def createAttendee(email: String) = EventbriteAttendee(Some(Vector(
+    EventbriteAnswer(
+      Some("Please tick for something else"),
+      Some("Not events and masterclasses")
+    ),
+    EventbriteAnswer(
+      Some("Please tick if you are interested in hearing about these products and services from Guardian News &amp; Media:"),
+      Some("Events &amp; Masterclasses: Learn from leading minds at our Guardian live events, including discussions and debates, short courses and bespoke training. Please confirm your selection[s] by clicking the link in \u200Bthe email\u200B that \u200Byou will receive shortly\u200B.")
+    ),
+  )), Some(EventbriteProfile(Some(email))))
+
+  val notAttending1= EventbriteAttendee(Some(Vector(
+    EventbriteAnswer(
+      Some("Please tick for something else"),
+      Some("Not events and masterclasses")
+    ),
+  )), Some(EventbriteProfile(Some("notattending@email.com"))))
+
+  val notAttending2= EventbriteAttendee(Some(Vector(
+    EventbriteAnswer(
+      Some("Please tick if you are interested in hearing about these products and services from Guardian News &amp; Media:"),
+      None,
+    ),
+  )), Some(EventbriteProfile(Some("notattending2@email.com"))))
+
+  "syncConsents" should "update event consents for users who are interested in events and masterclasses using events token and masterclasses token" in {
+    val fixtures = createFixtures()
+    import fixtures._
+
+    when(config.eventsToken) thenReturn "eventsToken"
+    when(config.masterclassesToken) thenReturn "masterclassesToken"
+    when(config.idapiAccessToken) thenReturn "idapiAccessToken"
+    when(config.idapiHost) thenReturn "idapiHost"
+    when(config.syncFrequencyHours) thenReturn 2
+
+
+    when(eventbriteClient.findConsents(eql("masterclassesToken"), any[Instant], eql(""))) thenReturn
+      EventbriteResponse(EventbritePagination(has_more_items = true, continuation = Some("cont1")), Some(Vector(createAttendee("email1@email.com"), createAttendee("email2@email.com"))))
+
+    when(eventbriteClient.findConsents(eql("masterclassesToken"), any[Instant], eql("cont1"))) thenReturn
+      EventbriteResponse(EventbritePagination(has_more_items = false, continuation = None), Some(Vector(notAttending2, createAttendee("email3@email.com"))))
+
+    when(eventbriteClient.findConsents(eql("eventsToken"), any[Instant], eql(""))) thenReturn
+      EventbriteResponse(EventbritePagination(has_more_items = true, continuation = Some("cont2")), Some(Vector(notAttending1, notAttending2)))
+
+    when(eventbriteClient.findConsents(eql("eventsToken"), any[Instant], eql("cont2"))) thenReturn
+      EventbriteResponse(EventbritePagination(has_more_items = false, continuation = None), Some(Vector(createAttendee("email4@email.com"))))
+
+    consentsService.syncConsents()
+    verify(identityClient).updateEventConsent("email1@email.com")
+    verify(identityClient).updateEventConsent("email2@email.com")
+    verify(identityClient).updateEventConsent("email3@email.com")
+    verify(identityClient).updateEventConsent("email4@email.com")
+    verifyNoMoreInteractions(identityClient)
+  }
+
+  "syncConsents" should "not update consents if no users are interested" in {
+    val fixtures = createFixtures()
+    import fixtures._
+
+    when(config.eventsToken) thenReturn "eventsToken"
+    when(config.masterclassesToken) thenReturn "masterclassesToken"
+    when(config.idapiAccessToken) thenReturn "idapiAccessToken"
+    when(config.idapiHost) thenReturn "idapiHost"
+    when(config.syncFrequencyHours) thenReturn 2
+
+
+    when(eventbriteClient.findConsents(eql("masterclassesToken"), any[Instant], eql(""))) thenReturn
+      EventbriteResponse(EventbritePagination(has_more_items = true, continuation = Some("cont1")), Some(Vector(notAttending2, notAttending1)))
+
+    when(eventbriteClient.findConsents(eql("masterclassesToken"), any[Instant], eql("cont1"))) thenReturn
+      EventbriteResponse(EventbritePagination(has_more_items = false, continuation = None), Some(Vector(notAttending2)))
+
+    when(eventbriteClient.findConsents(eql("eventsToken"), any[Instant], eql(""))) thenReturn
+      EventbriteResponse(EventbritePagination(has_more_items = false, continuation = None), Some(Vector(notAttending1, notAttending2)))
+
+
+    consentsService.syncConsents()
+    verifyNoMoreInteractions(identityClient)
+  }
+
+}


### PR DESCRIPTION
# Eventbrite consents sync Lambda

Scala lambda which hits the Eventbrite API and finds answers where users have ticked the 'hear more about guardian news and media' check box.

For positive answers the lambda hits the consent-emails endpoint idapi to trigger a confirmation email.

## Deployments

There is no CODE environment for Eventbrite. For testing we have a DEV Lambda which is configured with `isDebug=true`. This prevents the lambda
from updating the consents in Identity.

This Lambda was migrated from a defunct Python script running as a cron job.