### PR TITLE
Add dynamo status tables to Formstack-Baton-Requests

### DIFF
--- a/formstack-baton-requests/cloud-formation.yaml
+++ b/formstack-baton-requests/cloud-formation.yaml
@@ -19,6 +19,9 @@ Parameters:
     Description: Subnets to use in VPC
     Type: CommaDelimitedList
 
+Conditions:
+  IsProd: !Equals [ !Ref Stage, PROD ]
+
 Resources:
   FormstackBatonSarLambdaRole:
     Type: AWS::IAM::Role
@@ -89,3 +92,39 @@ Resources:
         SubnetIds: !Ref VpcSubnets
       Role:
         !GetAtt FormstackBatonSarLambdaRole.Arn
+
+#  There tables are only created in PROD since Formstack doesn't have a CODE environment and we don't want to test in
+#  CODE with real data
+  FormstackSubmissionIds:
+    Condition: IsProd
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: formstack-submission-ids
+      AttributeDefinitions:
+        - AttributeName: email
+          AttributeType: S
+        - AttributeName: submissionId
+          AttributeType: S
+      KeySchema:
+        - AttributeName: email
+          KeyType: HASH
+        - AttributeName: submissionId
+          KeyType: RANGE
+      ProvisionedThroughput:
+        ReadCapacityUnits: 5
+        WriteCapacityUnits: 5
+
+  FormstackSubmissionsLastUpdated:
+    Condition: IsProd
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: formstack-submissions-last-updated
+      AttributeDefinitions:
+        - AttributeName: formstackSubmissionTableMetadata
+          AttributeType: S
+      KeySchema:
+        - AttributeName: formstackSubmissionTableMetadata
+          KeyType: HASH
+      ProvisionedThroughput:
+        ReadCapacityUnits: 1
+        WriteCapacityUnits: 1


### PR DESCRIPTION
The aim of this PR is to create two tables (in PROD only) as part of the work for the Formstack SAR lambda. Formstack returns a paginated response for form submissions, which can take hours to iterate through. For this reason, we're going to get all these submissions once only, write them to dynamo and then only query formstack to update this table.

1. formstack-submission-ids 
This has an 'email' partition key (so we can search for a given email address) and 'submission id' as a sort key.

2. formstack-submissions-last-updated
This table is to store stateful metadata for the above-mentioned table. The reason for this table is to store when formstack-submission-ids was last updated. With this, we can make calls to Formstack's API to retrieve submissions SINCE the lastUpdated date and just update the formstack-submission-ids table with those submissions.