### PR TITLE
Correct baton role  

### DIFF
--- a/formstack-baton-requests/cloud-formation.yaml
+++ b/formstack-baton-requests/cloud-formation.yaml
@@ -49,7 +49,7 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              Service: ec2.amazonaws.com
+              AWS: !Sub "arn:aws:iam::942464564246:root"
             Action:
               - sts:AssumeRole
       Path: /


### PR DESCRIPTION
Didn't have the right permissions before so Baton wasn't able to assume the role.

Tested this in CODE.