### PR TITLE
Fix pages bug, modify submissions decoder and add alarms 

### DIFF
--- a/formstack-baton-requests/cloud-formation.yaml
+++ b/formstack-baton-requests/cloud-formation.yaml
@@ -41,6 +41,14 @@ Conditions:
   IsProd: !Equals [ !Ref Stage, PROD ]
 
 Resources:
+  TopicPagerDutyAlerts:
+    Type: AWS::SNS::Topic
+    Properties:
+      DisplayName: PagerDutyTopic
+      Subscription:
+        - Endpoint: https://events.pagerduty.com/adapter/cloudwatch_sns/v1/96fdc0179acb4c5db3e059d775ea6a9e
+          Protocol: https
+
   BatonInvokeRole:
     Type: AWS::IAM::Role
     Properties:
@@ -266,3 +274,21 @@ Resources:
     DependsOn:
       - PerformFormstackSarLambdaRole
 
+  FormstackBatonRequestsLambdaErrorAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmDescription: Alert when formstack baton request lambdas error
+      Namespace: AWS/Lambda
+      Dimensions:
+        - Name: BatonSarLambdaName
+          Value: !Ref FormstackBatonSarLambda
+        - Name: PerformSarLambdaName
+          Value: !Ref PerformFormstackSarLambda
+      MetricName: Errors
+      Statistic: Sum
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Threshold: '1'
+      Period: '60'
+      EvaluationPeriods: '1'
+      AlarmActions:
+        - !If [IsProd, !Ref 'TopicPagerDutyAlerts', !Ref 'AWS::NoValue']

--- a/formstack-baton-requests/src/local/com/gu/identity/formstackbatonrequests/FormstackBatonLambdaLocalRun.scala
+++ b/formstack-baton-requests/src/local/com/gu/identity/formstackbatonrequests/FormstackBatonLambdaLocalRun.scala
@@ -5,8 +5,7 @@ import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
 import BatonModels.{SarPerformRequest, SarRequest, SarStatusRequest}
 import io.circe.syntax._
 import circeCodecs._
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient
-import com.gu.identity.formstackbatonrequests.aws.{AwsCredentials, Dynamo, Lambda, S3}
+import com.gu.identity.formstackbatonrequests.aws.{Dynamo, Lambda, S3}
 
 /* This object can be used for local runs of the lambda, for end-to-end testing. */
 

--- a/formstack-baton-requests/src/main/scala/com/gu/identity/formstackbatonrequests/FormstackSarService.scala
+++ b/formstack-baton-requests/src/main/scala/com/gu/identity/formstackbatonrequests/FormstackSarService.scala
@@ -4,30 +4,14 @@ import com.typesafe.scalalogging.LazyLogging
 import scalaj.http.Http
 import io.circe.parser.decode
 import com.gu.identity.formstackbatonrequests.aws.SubmissionTableUpdateDate
-import io.circe.Json
-import io.circe.generic.JsonCodec
 import cats.implicits._
+import com.gu.identity.formstackbatonrequests.circeCodecs._
 
 trait FormstackSar {
   def accountFormsForGivenPage(page: Int, accountToken: FormstackAccountToken): Either[Throwable, FormsResponse]
   def formSubmissionsForGivenPage(page: Int, formId: String, minTime: SubmissionTableUpdateDate, encryptionPassword: String, accountToken: FormstackAccountToken): Either[Throwable, FormSubmissions]
   def submissionData(submissionIdEmails: List[SubmissionIdEmail], config: PerformSarLambdaConfig): Either[Throwable, List[FormstackSubmissionQuestionAnswer]]
 }
-/* Codecs for decoding accountFormsForGivenPage response */
-@JsonCodec case class Form(id: String)
-@JsonCodec case class FormsResponse(forms: List[Form], total: Int)
-
-/* Codecs for decoding formSubmissionsForGivenPage response */
-@JsonCodec case class ResponseValue(value: Json)
-@JsonCodec case class FormSubmission(id: String, data: Map[String, ResponseValue])
-@JsonCodec case class FormSubmissions(submissions: List[FormSubmission], pages: Int)
-
-/* Codecs for decoding submissionsById response */
-@JsonCodec case class SubmissionData(field: String, value: String)
-@JsonCodec case class Submission(id: String, timestamp: String, data: List[SubmissionData])
-
-/* Codecs for decoding retrieveSubmissionLabels*/
-@JsonCodec case class SubmissionLabelField(label: String)
 
 case class FormstackDecryptionError(message: String) extends Throwable
 

--- a/formstack-baton-requests/src/test/scala/com/gu/identity/formstackbatonrequests/CirceCodecsSpec.scala
+++ b/formstack-baton-requests/src/test/scala/com/gu/identity/formstackbatonrequests/CirceCodecsSpec.scala
@@ -106,5 +106,65 @@ class CirceCodecsSpec extends FreeSpec with Matchers {
       response.asJson.printWith(jsonPrinter) shouldBe """{"status":"failed","initiationReference":"someRequestId","subjectEmail":"testSubjectEmail","message":"Error writing to S3","action":"perform","requestType":"SAR","dataProvider":"formstack"}"""
     }
 
+    "should decode valid FormsSubmissions with data" in {
+      val jsonResponse =
+        """{
+          |"submissions": [
+          |{
+          |"id": "123456",
+          |"data": {"1111": {"field": "22", "value": "test", "flat_value": "test", "label": "Name"}, "1112": {"field": "23", "value": "email@test.com", "label": "Email"}}
+          |},
+          |{
+          |"id": "654321",
+          |"data": {"2222": {"field": "33", "value": "test2", "flat_value": "test2", "label": "Name2"}, "2223": {"field": "34", "value": "email@test2.com", "label": "Email"}}
+          |}],
+          |"pages": 2
+          |}
+          |""".stripMargin
+
+      decode[FormSubmissions](jsonResponse) shouldBe
+        Right(FormSubmissions(List(
+          FormSubmission("123456",
+            Map(
+              "1111" -> ResponseValue("test".asJson),
+              "1112" -> ResponseValue("email@test.com".asJson)
+            )),
+          FormSubmission("654321",
+            Map(
+              "2222" -> ResponseValue("test2".asJson),
+              "2223" -> ResponseValue("email@test2.com".asJson)
+            ))), 2))
+    }
+
+    "should decode valid FormsSubmissions without data" in {
+      val jsonResponse =
+        """{
+          |"submissions": [
+          |{
+          |"id": "123456",
+          |"data": []
+          |}],
+          |"pages": 2
+          |}
+          |""".stripMargin
+
+      decode[FormSubmissions](jsonResponse) shouldBe
+        Right(FormSubmissions(List(FormSubmission("123456", Map.empty)), 2))
+    }
+
+    "should fail to decode invalid FormsSubmissions" in {
+      val jsonResponse =
+        """{
+          |"submissions": [
+          |{
+          |"noId": "true",
+          |"data": []
+          |}],
+          |"pages": 2
+          |}
+          |""".stripMargin
+
+      decode[FormSubmissions](jsonResponse).isLeft shouldBe true
+    }
   }
 }

--- a/formstack-baton-requests/src/test/scala/com/gu/identity/formstackbatonrequests/FormstackSarServiceStub.scala
+++ b/formstack-baton-requests/src/test/scala/com/gu/identity/formstackbatonrequests/FormstackSarServiceStub.scala
@@ -1,6 +1,7 @@
 package com.gu.identity.formstackbatonrequests
 import com.gu.identity.formstackbatonrequests.aws.SubmissionTableUpdateDate
 import io.circe.syntax._
+import circeCodecs._
 
 class FormstackSarServiceStub(
   accountFormsForGivenPageResponse: Either[Throwable, FormsResponse],


### PR DESCRIPTION
This PR does a few things that I realised needed fixing when running the script:

- Move codecs into CirceCodecs file and add a custom decoder for FormSubmissions. Due to some inconsistencies in the Formstack API responses, sometimes data can be decoded to a Map[String, ResponseValue] but sometimes data is an empty array, which cannot be decoded to a Map[String, ResponseValue]. These responses are still valid, but they don't include data, so we can return Map.empty. Also added tests for this.

- Modified email regex to allow the end of email addresses to be between 2-6 letters long as I saw a few that were 5 letters long. Hopefully this will be good enough.

- Change recursive logic from (count + FormstackSarService.resultsPerPage) <= response.total to count < response.total as it was missing the last page.

- Added an alarm for errors.