### PR TITLE
update eventbrite api call

### DIFF
--- a/eventbrite-consents/cloud-formation.yaml
+++ b/eventbrite-consents/cloud-formation.yaml
@@ -6,7 +6,13 @@ Parameters:
     Description: key used to authenticate against the identity API
     Type: String
     NoEcho: true
+  MasterclassesOrganisation:
+    Type: String
+    NoEcho: true
   MasterclassesToken:
+    Type: String
+    NoEcho: true
+  EventsOrganisation:
     Type: String
     NoEcho: true
   EventsToken:
@@ -58,6 +64,8 @@ Resources:
           idapiAccessToken: !Ref IdapiAccessToken
           masterclassesToken: !Ref MasterclassesToken
           eventsToken: !Ref EventsToken
+          masterclassesOrganisation: !Ref MasterclassesOrganisation
+          eventsOrganisation: !Ref EventsOrganisation
           syncFrequencyHours: !FindInMap [SyncFrequencyMap, values, syncFrequencyHours]
           isDebug: !FindInMap [IsDebugMap, !Ref Stage, value]
       Handler: com.gu.identity.eventbriteconsents.Lambda::handler

--- a/eventbrite-consents/src/main/scala/com/gu/identity/eventbriteconsents/clients/EventbriteClient.scala
+++ b/eventbrite-consents/src/main/scala/com/gu/identity/eventbriteconsents/clients/EventbriteClient.scala
@@ -8,16 +8,18 @@ import io.circe.generic.auto._
 import io.circe.parser._
 import scalaj.http.Http
 
+case class EventbriteCredentials(organisationId: String, token: String)
+
 class EventbriteClient {
-  def findConsents(token: String, lastRun: Instant, continuationToken: String = ""): EventbriteResponse = {
+  def findConsents(credentials: EventbriteCredentials, lastRun: Instant, continuationToken: String = ""): EventbriteResponse = {
     val formattedLastRun = DateTimeFormatter
       .ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'")
       .withZone(ZoneId.of("UTC"))
       .format(lastRun)
 
-    val response = Http("https://www.eventbriteapi.com/v3/users/me/owned_event_attendees/")
+    val response = Http(s"https://www.eventbriteapi.com/v3/organizations/${credentials.organisationId}/attendees/")
       .headers(
-        "Authorization" -> s"Bearer $token",
+        "Authorization" -> s"Bearer ${credentials.token}",
         "Accept" -> "application/json"
       )
       .params(

--- a/eventbrite-consents/src/main/scala/com/gu/identity/eventbriteconsents/config/LambdaConfig.scala
+++ b/eventbrite-consents/src/main/scala/com/gu/identity/eventbriteconsents/config/LambdaConfig.scala
@@ -1,10 +1,12 @@
 package com.gu.identity.eventbriteconsents.config
 
+import com.gu.identity.eventbriteconsents.clients.EventbriteCredentials
+
 case class LambdaConfig(
   idapiHost: String,
   idapiAccessToken: String,
-  masterclassesToken: String,
-  eventsToken: String,
+  masterclassesCredentials: EventbriteCredentials,
+  eventsCredentials: EventbriteCredentials,
   syncFrequencyHours: Int,
   isDebug: Boolean,
 )
@@ -15,8 +17,8 @@ object LambdaConfig {
   def loadFromEnvironment(): LambdaConfig = LambdaConfig(
     idapiHost = loadConfigVar("idapiHost"),
     idapiAccessToken = loadConfigVar("idapiAccessToken"),
-    masterclassesToken = loadConfigVar("masterclassesToken"),
-    eventsToken = loadConfigVar("eventsToken"),
+    masterclassesCredentials = EventbriteCredentials(loadConfigVar("masterclassesOrganisation"), loadConfigVar("masterclassesToken")),
+    eventsCredentials = EventbriteCredentials(loadConfigVar("eventsOrganisation"), loadConfigVar("eventsToken")),
     syncFrequencyHours = loadConfigVar("syncFrequencyHours").toInt,
     isDebug = loadConfigVar("isDebug").toBoolean,
   )

--- a/eventbrite-consents/src/test/scala/com/gu/identity/eventbriteconsents/services/ConsentsServiceTest.scala
+++ b/eventbrite-consents/src/test/scala/com/gu/identity/eventbriteconsents/services/ConsentsServiceTest.scala
@@ -2,7 +2,7 @@ package com.gu.identity.eventbriteconsents.services
 
 import java.time.Instant
 
-import com.gu.identity.eventbriteconsents.clients.{EventbriteClient, IdentityClient}
+import com.gu.identity.eventbriteconsents.clients.{EventbriteClient, EventbriteCredentials, IdentityClient}
 import com.gu.identity.eventbriteconsents.config.LambdaConfig
 import com.gu.identity.eventbriteconsents.models.{EventbriteAnswer, EventbriteAttendee, EventbritePagination, EventbriteProfile, EventbriteResponse}
 import org.scalatest.FlatSpec
@@ -16,6 +16,8 @@ class ConsentsServiceTest extends FlatSpec with MockitoSugar {
     val config = mock[LambdaConfig]
     val eventbriteClient = mock[EventbriteClient]
     val identityClient = mock[IdentityClient]
+    val masterclassesCredentials = EventbriteCredentials("masterclassesOrganisationId", "masterclassesToken")
+    val eventsCredentials = EventbriteCredentials("eventsOrganisationId", "eventsToken")
     val consentsService = new ConsentsService(config, eventbriteClient, identityClient)
   }
 
@@ -48,24 +50,24 @@ class ConsentsServiceTest extends FlatSpec with MockitoSugar {
     val fixtures = createFixtures()
     import fixtures._
 
-    when(config.eventsToken) thenReturn "eventsToken"
-    when(config.masterclassesToken) thenReturn "masterclassesToken"
+    when(config.eventsCredentials) thenReturn eventsCredentials
+    when(config.masterclassesCredentials) thenReturn masterclassesCredentials
     when(config.idapiAccessToken) thenReturn "idapiAccessToken"
     when(config.idapiHost) thenReturn "idapiHost"
     when(config.syncFrequencyHours) thenReturn 2
     when(config.isDebug) thenReturn false
 
 
-    when(eventbriteClient.findConsents(eql("masterclassesToken"), any[Instant], eql(""))) thenReturn
+    when(eventbriteClient.findConsents(eql(masterclassesCredentials), any[Instant], eql(""))) thenReturn
       EventbriteResponse(EventbritePagination(has_more_items = true, continuation = Some("cont1")), Some(Vector(createAttendee("email1@email.com"), createAttendee("email2@email.com"))))
 
-    when(eventbriteClient.findConsents(eql("masterclassesToken"), any[Instant], eql("cont1"))) thenReturn
+    when(eventbriteClient.findConsents(eql(masterclassesCredentials), any[Instant], eql("cont1"))) thenReturn
       EventbriteResponse(EventbritePagination(has_more_items = false, continuation = None), Some(Vector(notAttending2, createAttendee("email3@email.com"))))
 
-    when(eventbriteClient.findConsents(eql("eventsToken"), any[Instant], eql(""))) thenReturn
+    when(eventbriteClient.findConsents(eql(eventsCredentials), any[Instant], eql(""))) thenReturn
       EventbriteResponse(EventbritePagination(has_more_items = true, continuation = Some("cont2")), Some(Vector(notAttending1, notAttending2)))
 
-    when(eventbriteClient.findConsents(eql("eventsToken"), any[Instant], eql("cont2"))) thenReturn
+    when(eventbriteClient.findConsents(eql(eventsCredentials), any[Instant], eql("cont2"))) thenReturn
       EventbriteResponse(EventbritePagination(has_more_items = false, continuation = None), Some(Vector(createAttendee("email4@email.com"))))
 
     consentsService.syncConsents()
@@ -80,21 +82,21 @@ class ConsentsServiceTest extends FlatSpec with MockitoSugar {
     val fixtures = createFixtures()
     import fixtures._
 
-    when(config.eventsToken) thenReturn "eventsToken"
-    when(config.masterclassesToken) thenReturn "masterclassesToken"
+    when(config.eventsCredentials) thenReturn eventsCredentials
+    when(config.masterclassesCredentials) thenReturn masterclassesCredentials
     when(config.idapiAccessToken) thenReturn "idapiAccessToken"
     when(config.idapiHost) thenReturn "idapiHost"
     when(config.syncFrequencyHours) thenReturn 2
     when(config.isDebug) thenReturn false
 
 
-    when(eventbriteClient.findConsents(eql("masterclassesToken"), any[Instant], eql(""))) thenReturn
+    when(eventbriteClient.findConsents(eql(masterclassesCredentials), any[Instant], eql(""))) thenReturn
       EventbriteResponse(EventbritePagination(has_more_items = true, continuation = Some("cont1")), Some(Vector(notAttending2, notAttending1)))
 
-    when(eventbriteClient.findConsents(eql("masterclassesToken"), any[Instant], eql("cont1"))) thenReturn
+    when(eventbriteClient.findConsents(eql(masterclassesCredentials), any[Instant], eql("cont1"))) thenReturn
       EventbriteResponse(EventbritePagination(has_more_items = false, continuation = None), Some(Vector(notAttending2)))
 
-    when(eventbriteClient.findConsents(eql("eventsToken"), any[Instant], eql(""))) thenReturn
+    when(eventbriteClient.findConsents(eql(eventsCredentials), any[Instant], eql(""))) thenReturn
       EventbriteResponse(EventbritePagination(has_more_items = false, continuation = None), Some(Vector(notAttending1, notAttending2)))
 
 
@@ -108,24 +110,24 @@ class ConsentsServiceTest extends FlatSpec with MockitoSugar {
     val fixtures = createFixtures()
     import fixtures._
 
-    when(config.eventsToken) thenReturn "eventsToken"
-    when(config.masterclassesToken) thenReturn "masterclassesToken"
+    when(config.eventsCredentials) thenReturn eventsCredentials
+    when(config.masterclassesCredentials) thenReturn masterclassesCredentials
     when(config.idapiAccessToken) thenReturn "idapiAccessToken"
     when(config.idapiHost) thenReturn "idapiHost"
     when(config.syncFrequencyHours) thenReturn 2
     when(config.isDebug) thenReturn true
 
 
-    when(eventbriteClient.findConsents(eql("masterclassesToken"), any[Instant], eql(""))) thenReturn
+    when(eventbriteClient.findConsents(eql(masterclassesCredentials), any[Instant], eql(""))) thenReturn
       EventbriteResponse(EventbritePagination(has_more_items = true, continuation = Some("cont1")), Some(Vector(createAttendee("email1@email.com"), createAttendee("email2@email.com"))))
 
-    when(eventbriteClient.findConsents(eql("masterclassesToken"), any[Instant], eql("cont1"))) thenReturn
+    when(eventbriteClient.findConsents(eql(masterclassesCredentials), any[Instant], eql("cont1"))) thenReturn
       EventbriteResponse(EventbritePagination(has_more_items = false, continuation = None), Some(Vector(notAttending2, createAttendee("email3@email.com"))))
 
-    when(eventbriteClient.findConsents(eql("eventsToken"), any[Instant], eql(""))) thenReturn
+    when(eventbriteClient.findConsents(eql(eventsCredentials), any[Instant], eql(""))) thenReturn
       EventbriteResponse(EventbritePagination(has_more_items = true, continuation = Some("cont2")), Some(Vector(notAttending1, notAttending2)))
 
-    when(eventbriteClient.findConsents(eql("eventsToken"), any[Instant], eql("cont2"))) thenReturn
+    when(eventbriteClient.findConsents(eql(eventsCredentials), any[Instant], eql("cont2"))) thenReturn
       EventbriteResponse(EventbritePagination(has_more_items = false, continuation = None), Some(Vector(createAttendee("email4@email.com"))))
 
     consentsService.syncConsents()


### PR DESCRIPTION
Eventbrite are changing their API. We now have to pass an organisation ID to a slightly different path. The response body and parameters are the same.

The API call is used to get users who have ticked a 'hear more from guardian events' button. We hit the API twice with 
- an events organisation id and token
- a masterclasses organisation id and token