### PR TITLE
Fix Formstack Permissions

### DIFF
--- a/formstack-baton-requests/cloud-formation.yaml
+++ b/formstack-baton-requests/cloud-formation.yaml
@@ -240,6 +240,22 @@ Resources:
                   - !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${FormstackAccountTwoTokenPath}
                   - !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${EncryptionPasswordPath}
                   - !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${BcryptSaltPath}
+        - PolicyName: SubmissionIdsTablePolicy
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action:
+                  - dynamodb:BatchWriteItem
+                  - dynamodb:Query
+                Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:table/formstack-submission-ids
+        - PolicyName: LastUpdatedTablePolicy
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action:
+                - dynamodb:GetItem
+                - dynamodb:PutItem
+                Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:table/formstack-submissions-last-updated
 
   PerformFormstackSarLambda:
     Type: AWS::Lambda::Function

--- a/formstack-baton-requests/cloud-formation.yaml
+++ b/formstack-baton-requests/cloud-formation.yaml
@@ -247,7 +247,7 @@ Resources:
                 Action:
                   - dynamodb:BatchWriteItem
                   - dynamodb:Query
-                Resource: !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/formstack-submission-ids
+                Resource: !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${SubmissionsTableName}
         - PolicyName: LastUpdatedTablePolicy
           PolicyDocument:
             Statement:
@@ -255,7 +255,7 @@ Resources:
                 Action:
                 - dynamodb:GetItem
                 - dynamodb:PutItem
-                Resource: !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/formstack-submissions-last-updated
+                Resource: !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${LastUpdatedTableName}
 
   PerformFormstackSarLambda:
     Type: AWS::Lambda::Function

--- a/formstack-baton-requests/cloud-formation.yaml
+++ b/formstack-baton-requests/cloud-formation.yaml
@@ -247,7 +247,7 @@ Resources:
                 Action:
                   - dynamodb:BatchWriteItem
                   - dynamodb:Query
-                Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:table/formstack-submission-ids
+                Resource: !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/formstack-submission-ids
         - PolicyName: LastUpdatedTablePolicy
           PolicyDocument:
             Statement:
@@ -255,7 +255,7 @@ Resources:
                 Action:
                 - dynamodb:GetItem
                 - dynamodb:PutItem
-                Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:table/formstack-submissions-last-updated
+                Resource: !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/formstack-submissions-last-updated
 
   PerformFormstackSarLambda:
     Type: AWS::Lambda::Function

--- a/formstack-baton-requests/src/main/scala/com/gu/identity/formstackbatonrequests/FormstackPerformSarHandler.scala
+++ b/formstack-baton-requests/src/main/scala/com/gu/identity/formstackbatonrequests/FormstackPerformSarHandler.scala
@@ -80,11 +80,12 @@ case class FormstackPerformSarHandler(
 
   def updateDynamo(submissionsTableUpdateDate: SubmissionTableUpdateDate): Either[Throwable, Unit] = {
     val timestampAsDate = LocalDateTime.parse(submissionsTableUpdateDate.date, SubmissionTableUpdateDate.formatter)
+    val timeOfStart = LocalDateTime.now
     if (timestampAsDate.toLocalDate != LocalDate.now) {
       for {
         _ <- updateSubmissionsTable(1, submissionsTableUpdateDate, FormstackSarService.resultsPerPage, config.accountOneToken)
         _ <- updateSubmissionsTable(1, submissionsTableUpdateDate, FormstackSarService.resultsPerPage, config.accountTwoToken)
-        _ <- dynamoClient.updateMostRecentTimestamp(config.lastUpdatedTableName, LocalDateTime.now)
+        _ <- dynamoClient.updateMostRecentTimestamp(config.lastUpdatedTableName, timeOfStart)
       } yield ()
     } else Right(())
   }

--- a/formstack-baton-requests/src/main/scala/com/gu/identity/formstackbatonrequests/Handler.scala
+++ b/formstack-baton-requests/src/main/scala/com/gu/identity/formstackbatonrequests/Handler.scala
@@ -64,7 +64,7 @@ object Handler {
   def handlePerformSar(inputStream: InputStream, outputStream: OutputStream): Unit = {
     val performSarHandlerConfig = FormstackConfig.getPerformSarHandlerConfig
     val performSarHandler =
-      if (stage == "CODE")
+      if (stage == "PROD")
         FormstackPerformSarHandler(Dynamo(), FormstackSarService, S3, performSarHandlerConfig)
       else FormstackPerformSarHandlerStub(S3, performSarHandlerConfig)
     performSarHandler.handleRequest(inputStream, outputStream)

--- a/formstack-baton-requests/src/main/scala/com/gu/identity/formstackbatonrequests/Handler.scala
+++ b/formstack-baton-requests/src/main/scala/com/gu/identity/formstackbatonrequests/Handler.scala
@@ -64,7 +64,7 @@ object Handler {
   def handlePerformSar(inputStream: InputStream, outputStream: OutputStream): Unit = {
     val performSarHandlerConfig = FormstackConfig.getPerformSarHandlerConfig
     val performSarHandler =
-      if (stage == "PROD")
+      if (stage == "CODE")
         FormstackPerformSarHandler(Dynamo(), FormstackSarService, S3, performSarHandlerConfig)
       else FormstackPerformSarHandlerStub(S3, performSarHandlerConfig)
     performSarHandler.handleRequest(inputStream, outputStream)


### PR DESCRIPTION
Formstack SAR isn't running because it didn't have the correct permissions to interact with Dynamo. This adds them.

Also using the start time of the lambda (rather than when the lambda finishes) as the 'last updated date' in case any submissions are made while the lambda is running.