### PR TITLE
Fix supported providers for Formstack requests

### DIFF
--- a/formstack-baton-requests/src/main/scala/com/gu/identity/formstackbatonrequests/Handler.scala
+++ b/formstack-baton-requests/src/main/scala/com/gu/identity/formstackbatonrequests/Handler.scala
@@ -20,19 +20,21 @@ trait FormstackHandler[Req, Res] extends LazyLogging {
 
   val jsonPrinter: Printer = Printer.spaces2.copy(dropNullValues = true)
 
-  private def checkFormstackDataProvider(request: Req): Either[Throwable, Unit] =
+  private def checkFormstackDataProvider(request: Req): Either[Throwable, Unit] = {
+    val supportedProviders = List("formstack", "formstackrer")
     request match {
       case _: SarStatusRequest => Right(())
       case _: RerStatusRequest => Right(())
       case SarInitiateRequest(_, dataProvider, _) =>
-        Either.cond(dataProvider == "formstack", (), DecodingFailure(s"invalid dataProvider: $dataProvider", List.empty))
+        Either.cond(supportedProviders.contains(dataProvider), (), DecodingFailure(s"invalid dataProvider: $dataProvider", List.empty))
       case SarPerformRequest(_, _, dataProvider) =>
-        Either.cond(dataProvider == "formstack", (), DecodingFailure(s"invalid dataProvider: $dataProvider", List.empty))
+        Either.cond(supportedProviders.contains(dataProvider), (), DecodingFailure(s"invalid dataProvider: $dataProvider", List.empty))
       case RerInitiateRequest(_, dataProvider, _) =>
-        Either.cond(dataProvider == "formstack", (), DecodingFailure(s"invalid dataProvider: $dataProvider", List.empty))
+        Either.cond(supportedProviders.contains(dataProvider), (), DecodingFailure(s"invalid dataProvider: $dataProvider", List.empty))
       case RerPerformRequest(_, _, dataProvider) =>
-        Either.cond(dataProvider == "formstack", (), DecodingFailure(s"invalid dataProvider: $dataProvider", List.empty))
+        Either.cond(supportedProviders.contains(dataProvider), (), DecodingFailure(s"invalid dataProvider: $dataProvider", List.empty))
     }
+  }
 
 
   private def checkRequestTypeMatchesRequest(request: Req): Either[Throwable, Unit] =


### PR DESCRIPTION
When I updated Baton to have a separate RER provider Formstack, I forgot to update the lambdas to support the new data provider.

This just extends the support to the FormstackRer data provider.

Tested in CODE.