### PR TITLE
Increase write capacity for Dynamo update

### DIFF
--- a/formstack-baton-requests/cloud-formation.yaml
+++ b/formstack-baton-requests/cloud-formation.yaml
@@ -249,6 +249,7 @@ Resources:
                 Action:
                   - dynamodb:BatchWriteItem
                   - dynamodb:Query
+                  - dynamodb:UpdateTable
                 Resource: !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${SubmissionsTableName}
         - PolicyName: LastUpdatedTablePolicy
           PolicyDocument:
@@ -344,6 +345,7 @@ Resources:
                 Action:
                   - dynamodb:BatchWriteItem
                   - dynamodb:Query
+                  - dynamodb:UpdateTable
                 Resource: !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${SubmissionsTableName}
         - PolicyName: LastUpdatedTablePolicy
           PolicyDocument:

--- a/formstack-baton-requests/src/main/scala/com/gu/identity/formstackbatonrequests/aws/DynamoClient.scala
+++ b/formstack-baton-requests/src/main/scala/com/gu/identity/formstackbatonrequests/aws/DynamoClient.scala
@@ -9,7 +9,7 @@ import com.gu.scanamo.Scanamo
 import com.github.t3hnar.bcrypt._
 import com.gu.scanamo.syntax._
 import cats.implicits._
-import com.amazonaws.services.dynamodbv2.model.{BatchWriteItemResult, DeleteItemResult}
+import com.amazonaws.services.dynamodbv2.model.{BatchWriteItemResult, DeleteItemResult, ProvisionedThroughput, UpdateTableRequest, UpdateTableResult}
 import com.gu.identity.formstackbatonrequests.sar.SubmissionIdEmail
 
 import scala.util.Try
@@ -20,6 +20,7 @@ trait DynamoClient {
   def updateMostRecentTimestamp(lastUpdatedTableName: String, currentDateTime: LocalDateTime): Either[Throwable, Unit]
   def userSubmissions(email: String, salt: String, submissionsTableName: String): Either[Throwable, List[SubmissionIdEmail]]
   def deleteUserSubmissions(submissionIdsAndEmails: List[SubmissionIdEmail], salt: String, submissionsTableName: String): Either[Throwable, List[DeleteItemResult]]
+  def updateWriteCapacity(units: Long, submissionsTableName: String): Either[Throwable, UpdateTableResult]
 }
 
 case class SubmissionTableUpdateDate(formstackSubmissionTableMetadata: String, date: String)
@@ -79,6 +80,13 @@ case class Dynamo(dynamoClient: AmazonDynamoDB = Dynamo.defaultDynamoClient) ext
         .delete(dynamoClient)(submissionsTableName)
         ('email -> submissionIdAndEmail.email and 'submissionId -> submissionIdAndEmail.submissionId)).toEither
     }
+  }
+
+  override def updateWriteCapacity(units: Long, submissionsTableName: String): Either[Throwable, UpdateTableResult] = {
+    val updateProvisionedThroughputRequest = new ProvisionedThroughput()
+        .withWriteCapacityUnits(units)
+        .withReadCapacityUnits(5L)
+    Try(dynamoClient.updateTable(submissionsTableName, updateProvisionedThroughputRequest)).toEither
   }
 }
 

--- a/formstack-baton-requests/src/main/scala/com/gu/identity/formstackbatonrequests/services/DynamoUpdateService.scala
+++ b/formstack-baton-requests/src/main/scala/com/gu/identity/formstackbatonrequests/services/DynamoUpdateService.scala
@@ -74,9 +74,12 @@ case class DynamoUpdateService(
     val timestampAsDate = LocalDateTime.parse(submissionsTableUpdateDate.date, SubmissionTableUpdateDate.formatter)
     val timeOfStart = LocalDateTime.now
     if (timestampAsDate.toLocalDate != LocalDate.now) {
+      logger.info(s"updating submissions table with submissions since $timestampAsDate")
       for {
+        _ <- dynamoClient.updateWriteCapacity(20L, config.submissionTableName)
         _ <- updateSubmissionsTable(1, submissionsTableUpdateDate, FormstackService.resultsPerPage, config.accountOneToken)
         _ <- updateSubmissionsTable(1, submissionsTableUpdateDate, FormstackService.resultsPerPage, config.accountTwoToken)
+        _ <- dynamoClient.updateWriteCapacity(5L, config.submissionTableName)
         _ <- dynamoClient.updateMostRecentTimestamp(config.lastUpdatedTableName, timeOfStart)
       } yield ()
     } else Right(())

--- a/formstack-baton-requests/src/test/scala/com/gu/identity/formstackbatonrequests/aws/DynamoClientStub.scala
+++ b/formstack-baton-requests/src/test/scala/com/gu/identity/formstackbatonrequests/aws/DynamoClientStub.scala
@@ -2,7 +2,7 @@ package com.gu.identity.formstackbatonrequests.aws
 
 import java.time.LocalDateTime
 
-import com.amazonaws.services.dynamodbv2.model.{BatchWriteItemResult, DeleteItemResult}
+import com.amazonaws.services.dynamodbv2.model.{BatchWriteItemResult, DeleteItemResult, UpdateTableResult}
 import com.gu.identity.formstackbatonrequests.sar.SubmissionIdEmail
 
 class DynamoClientStub(
@@ -10,13 +10,15 @@ class DynamoClientStub(
   updateMostRecentTimestampResponse: Either[Throwable, Unit],
   writeSubmissionsResponse: Either[Throwable, List[BatchWriteItemResult]],
   userSubmissionsResponse: Either[Throwable, List[SubmissionIdEmail]],
-  deleteUserSubmissionsResponse: Either[Throwable, List[DeleteItemResult]]
+  deleteUserSubmissionsResponse: Either[Throwable, List[DeleteItemResult]],
+  updateTableResponse: Either[Throwable, UpdateTableResult]
 ) extends DynamoClient {
   override def mostRecentTimestamp(lastUpdatedTableName: String): Either[Throwable, SubmissionTableUpdateDate] = mostRecentTimestampResponse
   override def updateMostRecentTimestamp(lastUpdatedTableName: String, currentDateTime: LocalDateTime): Either[Throwable, Unit] = updateMostRecentTimestampResponse
   override def writeSubmissions(submissionIdsAndEmails: List[SubmissionIdEmail], salt: String, submissionsTableName: String): Either[Throwable, List[BatchWriteItemResult]] = writeSubmissionsResponse
   override def userSubmissions(email: String, salt: String, submissionsTableName: String): Either[Throwable, List[SubmissionIdEmail]] = userSubmissionsResponse
   override def deleteUserSubmissions(submissionIdsAndEmails: List[SubmissionIdEmail], salt: String, submissionsTableName: String): Either[Throwable, List[DeleteItemResult]] = deleteUserSubmissionsResponse
+  override def updateWriteCapacity(units: Long, submissionsTableName: String): Either[Throwable, UpdateTableResult] = updateTableResponse
 }
 
 object DynamoClientStub {
@@ -25,8 +27,9 @@ object DynamoClientStub {
   val writeSubmissionsSuccess = Right(List.empty[BatchWriteItemResult])
   val userSubmissionsSuccess = Right(List(SubmissionIdEmail("test@test.com", "submissionId", 12345678, 1)))
   val deleteUserSubmissionsSuccess = Right(List.empty[DeleteItemResult])
+  val updateWriteCapacitySuccess = Right(new UpdateTableResult())
   val genericDynamoFailure = Left(new Exception("DynamoDB error"))
 
-  def withFailedResponse = new DynamoClientStub(genericDynamoFailure, genericDynamoFailure, genericDynamoFailure, genericDynamoFailure, genericDynamoFailure)
-  def withSuccessResponse = new DynamoClientStub(mostRecentTimestampSuccess, updateMostRecentTimestampSuccess, writeSubmissionsSuccess, userSubmissionsSuccess, deleteUserSubmissionsSuccess)
+  def withFailedResponse = new DynamoClientStub(genericDynamoFailure, genericDynamoFailure, genericDynamoFailure, genericDynamoFailure, genericDynamoFailure, genericDynamoFailure)
+  def withSuccessResponse = new DynamoClientStub(mostRecentTimestampSuccess, updateMostRecentTimestampSuccess, writeSubmissionsSuccess, userSubmissionsSuccess, deleteUserSubmissionsSuccess, updateWriteCapacitySuccess)
 }


### PR DESCRIPTION
When running the Dynamo table update locally the other day, I noticed that even though it's only updating since the last time the lambda ran, this sometimes comes extremely close to the lambda time limit (15 minutes). 

One way to improve the speed of the update is to increase the write capacity per second to  the submissions table Dynamo. This can be achieved by adjusting the provisioned throughput capacity depending on the resources being used. The problem with this approach is that it won't scale up until the target value is exceeded, and then it takes around 5 minutes for the actual increase to be in effect. If the target value isn't exceeded until the 11th minute, the lambda will never see the effect of this policy.

For this reason, I've included a step to increase the capacity manually at the start of every run, and reduce the capacity at the end. This is still not perfect, as it still takes 5 minutes for the change to come into effect. However, if there are a lot of submissions to be added to the table, at least the increased capacity will work after 5 minutes.

Hopefully this change will be enough... Otherwise, we might have to look into either:
- Separating the update from the rest of the SAR/RER process into it's own lambda and schedule the update daily so that there isn't a big gap between the times the table is updated
- Turning the lambdas in step functions with check conditions.