### PR TITLE
Add new Baton account invoke role

### DIFF
--- a/formstack-baton-requests/cloud-formation.yaml
+++ b/formstack-baton-requests/cloud-formation.yaml
@@ -36,6 +36,8 @@ Parameters:
   SubmissionsTableName:
     Type: String
     Default: formstack-submission-ids
+  BatonAccountId:
+    Type: String
 
 Conditions:
   IsProd: !Equals [ !Ref Stage, PROD ]
@@ -49,7 +51,7 @@ Resources:
         - Endpoint: https://events.pagerduty.com/adapter/cloudwatch_sns/v1/96fdc0179acb4c5db3e059d775ea6a9e
           Protocol: https
 
-  BatonInvokeRole:
+  BatonInvokeRole: #TODO delete once Baton is migrated to new account
     Type: AWS::IAM::Role
     Properties:
       RoleName: !Sub "formstack-baton-lambda-role-${Stage}"
@@ -58,6 +60,29 @@ Resources:
           - Effect: Allow
             Principal:
               AWS: !Sub "arn:aws:iam::942464564246:root"
+            Action:
+              - sts:AssumeRole
+      Path: /
+      Policies:
+        - PolicyName: LambdaPolicy
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action:
+                  - lambda:InvokeFunction
+                Resource:
+                  - !GetAtt FormstackBatonSarLambda.Arn
+                  - !GetAtt FormstackBatonRerLambda.Arn
+
+  BatonAccountInvokeRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub "baton-formstack-lambda-role-${Stage}"
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !Sub "arn:aws:iam::${BatonAccountId}:root"
             Action:
               - sts:AssumeRole
       Path: /


### PR DESCRIPTION
### Why are you making this change?
This adds permissions for the Formstack SAR and RER init lambdas to be invoked from the new Baton AWS account.

The identity invoke role will be deleted once the migration is completed.

### What background information is there? (e.g. an [ADR](https://github.com/guardian/ophan-data-lake/blob/master/decisions/template.md), Trello card, PR, or Issue)

https://trello.com/c/oFgWKRhL/858-add-role-to-all-lambdas-for-new-baton-aws-account
