### PR TITLE
Fix lambda to not break when continuation and has_more_items fields are absent in the Eventbrite response

### DIFF
--- a/eventbrite-consents/README.md
+++ b/eventbrite-consents/README.md
@@ -29,7 +29,9 @@ Run with SBT
 ```
 export idapiHost=not_used_in_debug
 export idapiAccessToken=not_used_in_debug
+export masterclassesOrganisation=set_this
 export masterclassesToken=set_this
+export eventsOrganisation=set_this
 export eventsToken=set_this
 export syncFrequencyHours=4
 export isDebug=true

--- a/eventbrite-consents/src/main/scala/com/gu/identity/eventbriteconsents/models/EventbriteModels.scala
+++ b/eventbrite-consents/src/main/scala/com/gu/identity/eventbriteconsents/models/EventbriteModels.scala
@@ -18,10 +18,21 @@ case class EventbriteAttendee(answers: Option[Vector[EventbriteAnswer]], profile
   val answersList: Vector[EventbriteAnswer] = answers.toVector.flatten
 }
 
-case class EventbritePagination(has_more_items: Boolean, continuation: Option[String]) {
-  val continuationToken: Option[String] = this match {
-    case EventbritePagination(true, Some(cont)) => Some(cont)
-    case _ => None
+case class EventbritePagination(
+  has_more_items: Boolean = false,
+  continuation: Option[String] = None,
+  page_count: Int,
+  page_number: Int
+) {
+  def continuationToken: Option[String] = {
+    if (this.page_count > this.page_number && this.continuation.isEmpty) {
+      throw new RuntimeException("Eventbrite pagination shows there are more pages to process but continuation token is absent")
+    } else {
+      this match {
+        case EventbritePagination(true, Some(cont), _, _) => Some(cont)
+        case _ => None
+      }
+    }
   }
 }
 

--- a/eventbrite-consents/src/test/scala/com/gu/identity/eventbriteconsents/services/ConsentsServiceTest.scala
+++ b/eventbrite-consents/src/test/scala/com/gu/identity/eventbriteconsents/services/ConsentsServiceTest.scala
@@ -19,6 +19,12 @@ class ConsentsServiceTest extends FlatSpec with MockitoSugar {
     val masterclassesCredentials = EventbriteCredentials("masterclassesOrganisationId", "masterclassesToken")
     val eventsCredentials = EventbriteCredentials("eventsOrganisationId", "eventsToken")
     val consentsService = new ConsentsService(config, eventbriteClient, identityClient)
+
+    when(config.eventsCredentials) thenReturn eventsCredentials
+    when(config.masterclassesCredentials) thenReturn masterclassesCredentials
+    when(config.idapiAccessToken) thenReturn "idapiAccessToken"
+    when(config.idapiHost) thenReturn "idapiHost"
+    when(config.syncFrequencyHours) thenReturn 2
   }
 
   def createAttendee(email: String) = EventbriteAttendee(Some(Vector(
@@ -50,25 +56,19 @@ class ConsentsServiceTest extends FlatSpec with MockitoSugar {
     val fixtures = createFixtures()
     import fixtures._
 
-    when(config.eventsCredentials) thenReturn eventsCredentials
-    when(config.masterclassesCredentials) thenReturn masterclassesCredentials
-    when(config.idapiAccessToken) thenReturn "idapiAccessToken"
-    when(config.idapiHost) thenReturn "idapiHost"
-    when(config.syncFrequencyHours) thenReturn 2
     when(config.isDebug) thenReturn false
 
-
     when(eventbriteClient.findConsents(eql(masterclassesCredentials), any[Instant], eql(""))) thenReturn
-      EventbriteResponse(EventbritePagination(has_more_items = true, continuation = Some("cont1")), Some(Vector(createAttendee("email1@email.com"), createAttendee("email2@email.com"))))
+      EventbriteResponse(EventbritePagination(has_more_items = true, continuation = Some("cont1"), 1, 1), Some(Vector(createAttendee("email1@email.com"), createAttendee("email2@email.com"))))
 
     when(eventbriteClient.findConsents(eql(masterclassesCredentials), any[Instant], eql("cont1"))) thenReturn
-      EventbriteResponse(EventbritePagination(has_more_items = false, continuation = None), Some(Vector(notAttending2, createAttendee("email3@email.com"))))
+      EventbriteResponse(EventbritePagination(has_more_items = false, continuation = None, 1, 1), Some(Vector(notAttending2, createAttendee("email3@email.com"))))
 
     when(eventbriteClient.findConsents(eql(eventsCredentials), any[Instant], eql(""))) thenReturn
-      EventbriteResponse(EventbritePagination(has_more_items = true, continuation = Some("cont2")), Some(Vector(notAttending1, notAttending2)))
+      EventbriteResponse(EventbritePagination(has_more_items = true, continuation = Some("cont2"), 1, 1), Some(Vector(notAttending1, notAttending2)))
 
     when(eventbriteClient.findConsents(eql(eventsCredentials), any[Instant], eql("cont2"))) thenReturn
-      EventbriteResponse(EventbritePagination(has_more_items = false, continuation = None), Some(Vector(createAttendee("email4@email.com"))))
+      EventbriteResponse(EventbritePagination(has_more_items = false, continuation = None, 1, 1), Some(Vector(createAttendee("email4@email.com"))))
 
     consentsService.syncConsents()
     verify(identityClient).updateEventConsent("email1@email.com")
@@ -82,22 +82,16 @@ class ConsentsServiceTest extends FlatSpec with MockitoSugar {
     val fixtures = createFixtures()
     import fixtures._
 
-    when(config.eventsCredentials) thenReturn eventsCredentials
-    when(config.masterclassesCredentials) thenReturn masterclassesCredentials
-    when(config.idapiAccessToken) thenReturn "idapiAccessToken"
-    when(config.idapiHost) thenReturn "idapiHost"
-    when(config.syncFrequencyHours) thenReturn 2
     when(config.isDebug) thenReturn false
 
-
     when(eventbriteClient.findConsents(eql(masterclassesCredentials), any[Instant], eql(""))) thenReturn
-      EventbriteResponse(EventbritePagination(has_more_items = true, continuation = Some("cont1")), Some(Vector(notAttending2, notAttending1)))
+      EventbriteResponse(EventbritePagination(has_more_items = true, continuation = Some("cont1"), 1, 1), Some(Vector(notAttending2, notAttending1)))
 
     when(eventbriteClient.findConsents(eql(masterclassesCredentials), any[Instant], eql("cont1"))) thenReturn
-      EventbriteResponse(EventbritePagination(has_more_items = false, continuation = None), Some(Vector(notAttending2)))
+      EventbriteResponse(EventbritePagination(has_more_items = false, continuation = None, 1, 1), Some(Vector(notAttending2)))
 
     when(eventbriteClient.findConsents(eql(eventsCredentials), any[Instant], eql(""))) thenReturn
-      EventbriteResponse(EventbritePagination(has_more_items = false, continuation = None), Some(Vector(notAttending1, notAttending2)))
+      EventbriteResponse(EventbritePagination(has_more_items = false, continuation = None, 1, 1), Some(Vector(notAttending1, notAttending2)))
 
 
     consentsService.syncConsents()
@@ -110,28 +104,35 @@ class ConsentsServiceTest extends FlatSpec with MockitoSugar {
     val fixtures = createFixtures()
     import fixtures._
 
-    when(config.eventsCredentials) thenReturn eventsCredentials
-    when(config.masterclassesCredentials) thenReturn masterclassesCredentials
-    when(config.idapiAccessToken) thenReturn "idapiAccessToken"
-    when(config.idapiHost) thenReturn "idapiHost"
-    when(config.syncFrequencyHours) thenReturn 2
     when(config.isDebug) thenReturn true
 
-
     when(eventbriteClient.findConsents(eql(masterclassesCredentials), any[Instant], eql(""))) thenReturn
-      EventbriteResponse(EventbritePagination(has_more_items = true, continuation = Some("cont1")), Some(Vector(createAttendee("email1@email.com"), createAttendee("email2@email.com"))))
+      EventbriteResponse(EventbritePagination(has_more_items = true, continuation = Some("cont1"), 1, 1), Some(Vector(createAttendee("email1@email.com"), createAttendee("email2@email.com"))))
 
     when(eventbriteClient.findConsents(eql(masterclassesCredentials), any[Instant], eql("cont1"))) thenReturn
-      EventbriteResponse(EventbritePagination(has_more_items = false, continuation = None), Some(Vector(notAttending2, createAttendee("email3@email.com"))))
+      EventbriteResponse(EventbritePagination(has_more_items = false, continuation = None, 1, 1), Some(Vector(notAttending2, createAttendee("email3@email.com"))))
 
     when(eventbriteClient.findConsents(eql(eventsCredentials), any[Instant], eql(""))) thenReturn
-      EventbriteResponse(EventbritePagination(has_more_items = true, continuation = Some("cont2")), Some(Vector(notAttending1, notAttending2)))
+      EventbriteResponse(EventbritePagination(has_more_items = true, continuation = Some("cont2"), 1, 1), Some(Vector(notAttending1, notAttending2)))
 
     when(eventbriteClient.findConsents(eql(eventsCredentials), any[Instant], eql("cont2"))) thenReturn
-      EventbriteResponse(EventbritePagination(has_more_items = false, continuation = None), Some(Vector(createAttendee("email4@email.com"))))
+      EventbriteResponse(EventbritePagination(has_more_items = false, continuation = None, 1, 1), Some(Vector(createAttendee("email4@email.com"))))
 
     consentsService.syncConsents()
     verifyZeroInteractions(identityClient)
   }
 
+  "syncConsents" should "throw an error when there are additional pages to process but no continuation token is found" in {
+    val fixtures = createFixtures()
+    import fixtures._
+
+    when(config.isDebug) thenReturn false
+
+    when(eventbriteClient.findConsents(eql(masterclassesCredentials), any[Instant], eql(""))) thenReturn
+      EventbriteResponse(EventbritePagination(has_more_items = false, continuation = None, 2, 1), None)
+
+    assertThrows[RuntimeException] {
+      consentsService.syncConsents()
+    }
+  }
 }


### PR DESCRIPTION
## What does this change?
The Eventbrite API does not always send a response with the pagination.continuation and pagination.has_more_items fields. This PR adapts our current model to allow for these fields to be absent, provided the page count is less than the current page number (ie, there are no more pages to process).

## How to test
There are instructions in the README.md on how to run this locally in DEV

## How can we measure success?
We should no longer have failing Eventbrite consent jobs when pagination.continuation and pagination.has_more_items are absent for valid reasons.

## Have we considered potential risks?
Yes