### PR TITLE
Update README with additional environment variables

### DIFF
--- a/eventbrite-consents/README.md
+++ b/eventbrite-consents/README.md
@@ -37,7 +37,6 @@ export isDebug=true
 sbt run
 ```
 
-
 or run the com.gu.identity.eventbriteconsents.Lambda.main function with environment variables set in Intellij.
 
 ## Unit tests

--- a/eventbrite-consents/README.md
+++ b/eventbrite-consents/README.md
@@ -24,17 +24,19 @@ To run the app locally set the environment variables for the app (including API 
 in DEV and PROD can be found in the Lambda environment configuration on the AWS console. Be careful, if `isDebug=false` then
 emails could potentially be sent to users if idapiHost and idapiAccessToken are set.
 
-
 Run with SBT
 ```
 export idapiHost=not_used_in_debug
 export idapiAccessToken=not_used_in_debug
+export masterclassesOrganisation=set_this
 export masterclassesToken=set_this
+export eventsOrganisation=set_this
 export eventsToken=set_this
 export syncFrequencyHours=4
 export isDebug=true
 sbt run
 ```
+
 
 or run the com.gu.identity.eventbriteconsents.Lambda.main function with environment variables set in Intellij.
 


### PR DESCRIPTION
`masterclassesOrganisation` and `eventsOrganisation` are two additional environment variables that were added a few months ago. This PR updates the README instructions on how to run the app locally to include these variables.