### PR TITLE
has more items is not always being returned so mark it as optional

### DIFF
--- a/eventbrite-consents/src/main/scala/com/gu/identity/eventbriteconsents/models/EventbriteModels.scala
+++ b/eventbrite-consents/src/main/scala/com/gu/identity/eventbriteconsents/models/EventbriteModels.scala
@@ -18,9 +18,9 @@ case class EventbriteAttendee(answers: Option[Vector[EventbriteAnswer]], profile
   val answersList: Vector[EventbriteAnswer] = answers.toVector.flatten
 }
 
-case class EventbritePagination(has_more_items: Boolean, continuation: Option[String]) {
+case class EventbritePagination(has_more_items: Option[Boolean], continuation: Option[String]) {
   val continuationToken: Option[String] = this match {
-    case EventbritePagination(true, Some(cont)) => Some(cont)
+    case EventbritePagination(Some(true), Some(cont)) => Some(cont)
     case _ => None
   }
 }

--- a/eventbrite-consents/src/test/scala/com/gu/identity/eventbriteconsents/services/ConsentsServiceTest.scala
+++ b/eventbrite-consents/src/test/scala/com/gu/identity/eventbriteconsents/services/ConsentsServiceTest.scala
@@ -59,16 +59,16 @@ class ConsentsServiceTest extends FlatSpec with MockitoSugar {
 
 
     when(eventbriteClient.findConsents(eql(masterclassesCredentials), any[Instant], eql(""))) thenReturn
-      EventbriteResponse(EventbritePagination(has_more_items = true, continuation = Some("cont1")), Some(Vector(createAttendee("email1@email.com"), createAttendee("email2@email.com"))))
+      EventbriteResponse(EventbritePagination(has_more_items = Some(true), continuation = Some("cont1")), Some(Vector(createAttendee("email1@email.com"), createAttendee("email2@email.com"))))
 
     when(eventbriteClient.findConsents(eql(masterclassesCredentials), any[Instant], eql("cont1"))) thenReturn
-      EventbriteResponse(EventbritePagination(has_more_items = false, continuation = None), Some(Vector(notAttending2, createAttendee("email3@email.com"))))
+      EventbriteResponse(EventbritePagination(has_more_items = Some(false), continuation = None), Some(Vector(notAttending2, createAttendee("email3@email.com"))))
 
     when(eventbriteClient.findConsents(eql(eventsCredentials), any[Instant], eql(""))) thenReturn
-      EventbriteResponse(EventbritePagination(has_more_items = true, continuation = Some("cont2")), Some(Vector(notAttending1, notAttending2)))
+      EventbriteResponse(EventbritePagination(has_more_items = Some(true), continuation = Some("cont2")), Some(Vector(notAttending1, notAttending2)))
 
     when(eventbriteClient.findConsents(eql(eventsCredentials), any[Instant], eql("cont2"))) thenReturn
-      EventbriteResponse(EventbritePagination(has_more_items = false, continuation = None), Some(Vector(createAttendee("email4@email.com"))))
+      EventbriteResponse(EventbritePagination(has_more_items = Some(false), continuation = None), Some(Vector(createAttendee("email4@email.com"))))
 
     consentsService.syncConsents()
     verify(identityClient).updateEventConsent("email1@email.com")
@@ -91,13 +91,13 @@ class ConsentsServiceTest extends FlatSpec with MockitoSugar {
 
 
     when(eventbriteClient.findConsents(eql(masterclassesCredentials), any[Instant], eql(""))) thenReturn
-      EventbriteResponse(EventbritePagination(has_more_items = true, continuation = Some("cont1")), Some(Vector(notAttending2, notAttending1)))
+      EventbriteResponse(EventbritePagination(has_more_items = Some(true), continuation = Some("cont1")), Some(Vector(notAttending2, notAttending1)))
 
     when(eventbriteClient.findConsents(eql(masterclassesCredentials), any[Instant], eql("cont1"))) thenReturn
-      EventbriteResponse(EventbritePagination(has_more_items = false, continuation = None), Some(Vector(notAttending2)))
+      EventbriteResponse(EventbritePagination(has_more_items = Some(false), continuation = None), Some(Vector(notAttending2)))
 
     when(eventbriteClient.findConsents(eql(eventsCredentials), any[Instant], eql(""))) thenReturn
-      EventbriteResponse(EventbritePagination(has_more_items = false, continuation = None), Some(Vector(notAttending1, notAttending2)))
+      EventbriteResponse(EventbritePagination(has_more_items = Some(false), continuation = None), Some(Vector(notAttending1, notAttending2)))
 
 
     consentsService.syncConsents()
@@ -119,16 +119,16 @@ class ConsentsServiceTest extends FlatSpec with MockitoSugar {
 
 
     when(eventbriteClient.findConsents(eql(masterclassesCredentials), any[Instant], eql(""))) thenReturn
-      EventbriteResponse(EventbritePagination(has_more_items = true, continuation = Some("cont1")), Some(Vector(createAttendee("email1@email.com"), createAttendee("email2@email.com"))))
+      EventbriteResponse(EventbritePagination(has_more_items = Some(true), continuation = Some("cont1")), Some(Vector(createAttendee("email1@email.com"), createAttendee("email2@email.com"))))
 
     when(eventbriteClient.findConsents(eql(masterclassesCredentials), any[Instant], eql("cont1"))) thenReturn
-      EventbriteResponse(EventbritePagination(has_more_items = false, continuation = None), Some(Vector(notAttending2, createAttendee("email3@email.com"))))
+      EventbriteResponse(EventbritePagination(has_more_items = Some(false), continuation = None), Some(Vector(notAttending2, createAttendee("email3@email.com"))))
 
     when(eventbriteClient.findConsents(eql(eventsCredentials), any[Instant], eql(""))) thenReturn
-      EventbriteResponse(EventbritePagination(has_more_items = true, continuation = Some("cont2")), Some(Vector(notAttending1, notAttending2)))
+      EventbriteResponse(EventbritePagination(has_more_items = Some(true), continuation = Some("cont2")), Some(Vector(notAttending1, notAttending2)))
 
     when(eventbriteClient.findConsents(eql(eventsCredentials), any[Instant], eql("cont2"))) thenReturn
-      EventbriteResponse(EventbritePagination(has_more_items = false, continuation = None), Some(Vector(createAttendee("email4@email.com"))))
+      EventbriteResponse(EventbritePagination(has_more_items = Some(false), continuation = None), Some(Vector(createAttendee("email4@email.com"))))
 
     consentsService.syncConsents()
     verifyZeroInteractions(identityClient)


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
has_more_items on the eventbrite response is not always being returned so mark it as optional

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
Eventbrite consents lambda does not fail when the API fails to set the field has_more_items

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
