### PR TITLE
Update alarm names and send emails via AWS SNS topic rather than Pagerduty

### DIFF
--- a/eventbrite-consents/cloud-formation.yaml
+++ b/eventbrite-consents/cloud-formation.yaml
@@ -24,6 +24,9 @@ Parameters:
     AllowedValues:
       - DEV
       - PROD
+  AlarmEmailAddress:
+    Description: Contact email for alarms
+    Type: String
 
 Conditions:
   IsProd: !Equals
@@ -43,13 +46,13 @@ Mappings:
       syncFrequencyHours: 4
 
 Resources:
-  TopicPagerDutyAlerts:
+  TopicSendEmail:
     Type: AWS::SNS::Topic
     Properties:
-      DisplayName: PagerDutyTopic
+      DisplayName: SendEmailTopic
       Subscription:
-      - Endpoint: https://events.pagerduty.com/adapter/cloudwatch_sns/v1/96fdc0179acb4c5db3e059d775ea6a9e
-        Protocol: https
+        - Endpoint: !Ref 'AlarmEmailAddress'
+          Protocol: email
 
   EventbriteConsentsLambda:
     Type: AWS::Serverless::Function
@@ -95,6 +98,7 @@ Resources:
   EventbriteConsentsLambdaErrorAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
+      AlarmName: !Sub 'eventbrite-consents-lambda-${Stage} failed execution'
       AlarmDescription: Alert when eventbrite consents lambda errors
       Namespace: AWS/Lambda
       Dimensions:
@@ -107,4 +111,4 @@ Resources:
       Period: '60'
       EvaluationPeriods: '1'
       AlarmActions:
-      - !If [IsProd, !Ref 'TopicPagerDutyAlerts', !Ref 'AWS::NoValue']
+      - !If [IsProd, !Ref 'TopicSendEmail', !Ref 'AWS::NoValue']

--- a/formstack-baton-requests/cloud-formation.yaml
+++ b/formstack-baton-requests/cloud-formation.yaml
@@ -38,18 +38,21 @@ Parameters:
     Default: formstack-submission-ids
   BatonAccountId:
     Type: String
+  AlarmEmailAddress:
+    Description: Contact email for alarms
+    Type: String
 
 Conditions:
   IsProd: !Equals [ !Ref Stage, PROD ]
 
 Resources:
-  TopicPagerDutyAlerts:
+  TopicSendEmail:
     Type: AWS::SNS::Topic
     Properties:
-      DisplayName: PagerDutyTopic
+      DisplayName: SendEmailTopic
       Subscription:
-        - Endpoint: https://events.pagerduty.com/adapter/cloudwatch_sns/v1/96fdc0179acb4c5db3e059d775ea6a9e
-          Protocol: https
+        - Endpoint: !Ref 'AlarmEmailAddress'
+          Protocol: email
 
   BatonAccountInvokeRole:
     Type: AWS::IAM::Role
@@ -556,6 +559,7 @@ Resources:
   FormstackBatonRequestsLambdaErrorAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
+      AlarmName: !Sub 'formstack-baton-requests-lambda-${Stage} failed execution'
       AlarmDescription: Alert when formstack baton request lambdas error
       Namespace: AWS/Lambda
       Dimensions:
@@ -570,7 +574,7 @@ Resources:
       Period: '60'
       EvaluationPeriods: '1'
       AlarmActions:
-        - !If [IsProd, !Ref 'TopicPagerDutyAlerts', !Ref 'AWS::NoValue']
+        - !If [IsProd, !Ref 'TopicSendEmail', !Ref 'AWS::NoValue']
 
   # ****************************************************************************
   # Step Function and Role

--- a/formstack-consents/cloud-formation.yaml
+++ b/formstack-consents/cloud-formation.yaml
@@ -20,6 +20,9 @@ Parameters:
   FormstackSharedSecret:
     Description: The shared secret is included in the form submission data
     Type: String
+  AlarmEmailAddress:
+    Description: Contact email for alarms
+    Type: String
 
 Conditions:
   IsProd: !Equals
@@ -27,13 +30,13 @@ Conditions:
   - PROD
 
 Resources:
-  TopicPagerDutyAlerts:
+  TopicSendEmail:
     Type: AWS::SNS::Topic
     Properties:
-      DisplayName: PagerDutyTopic
+      DisplayName: SendEmailTopic
       Subscription:
-      - Endpoint: https://events.pagerduty.com/adapter/cloudwatch_sns/v1/96fdc0179acb4c5db3e059d775ea6a9e
-        Protocol: https
+        - Endpoint: !Ref 'AlarmEmailAddress'
+          Protocol: email
 
   FormstackConsentsLambda:
     Type: AWS::Serverless::Function
@@ -95,6 +98,7 @@ Resources:
   FormstackConsentsLambdaErrorAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
+      AlarmName: !Sub 'formstack-consents-lambda-${Stage} failed execution'
       AlarmDescription: Alert when formstack consents lambda errors
       Namespace: AWS/Lambda
       Dimensions:
@@ -107,4 +111,4 @@ Resources:
       Period: '60'
       EvaluationPeriods: '1'
       AlarmActions:
-      - !If [IsProd, !Ref 'TopicPagerDutyAlerts', !Ref 'AWS::NoValue']
+      - !If [IsProd, !Ref 'TopicSendEmail', !Ref 'AWS::NoValue']

--- a/payment-failure/cloud-formation.yaml
+++ b/payment-failure/cloud-formation.yaml
@@ -46,13 +46,6 @@ Resources:
       Subscription:
         - Endpoint: !Ref 'AlarmEmailAddress'
           Protocol: email
-  TopicPagerDutyAlerts:
-    Type: AWS::SNS::Topic
-    Properties:
-      DisplayName: PagerDutyTopic
-      Subscription:
-      - Endpoint: https://events.pagerduty.com/adapter/cloudwatch_sns/v1/96fdc0179acb4c5db3e059d775ea6a9e
-        Protocol: https
   PaymentFailureLambdaRole:
     Type: AWS::IAM::Role
     Properties:

--- a/payment-failure/cloud-formation.yaml
+++ b/payment-failure/cloud-formation.yaml
@@ -152,8 +152,7 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmName: !Sub 'payment-failure-lambda-${Stage} Message added to payment failure dead letter queue'
-      AlarmDescription: Alarm if payment failure dead letter queue grows beyond 1
-        message
+      AlarmDescription: Alarm if payment failure dead letter queue grows beyond 1 message
       Namespace: AWS/SQS
       MetricName: ApproximateNumberOfMessagesVisible
       Dimensions:
@@ -173,8 +172,7 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmName: !Sub 'payment-failure-lambda-${Stage} Too many messages on the payment failure queue'
-      AlarmDescription: Alarm if payment failure queue grows beyond 300
-        message
+      AlarmDescription: Alarm if payment failure queue grows beyond 300 messages
       Namespace: AWS/SQS
       MetricName: ApproximateNumberOfMessagesVisible
       Dimensions:

--- a/payment-failure/cloud-formation.yaml
+++ b/payment-failure/cloud-formation.yaml
@@ -30,12 +30,22 @@ Parameters:
   SQSQueueUrl:
     Description: url of the queue that contains payment failure messages
     Type: String
+  AlarmEmailAddress:
+    Description: Contact email for alarms
+    Type: String
 
 Conditions:
   IsProd: !Equals
     - !Ref 'Stage'
     - PROD
 Resources:
+  TopicSendEmail:
+    Type: AWS::SNS::Topic
+    Properties:
+      DisplayName: SendEmailTopic
+      Subscription:
+        - Endpoint: !Ref 'AlarmEmailAddress'
+          Protocol: email
   TopicPagerDutyAlerts:
     Type: AWS::SNS::Topic
     Properties:
@@ -148,6 +158,7 @@ Resources:
   PaymentFailureDeadLetterQueueAlert:
     Type: AWS::CloudWatch::Alarm
     Properties:
+      AlarmName: !Sub 'payment-failure-lambda-${Stage} Message added to payment failure dead letter queue'
       AlarmDescription: Alarm if payment failure dead letter queue grows beyond 1
         message
       Namespace: AWS/SQS
@@ -161,13 +172,14 @@ Resources:
       Threshold: '0'
       ComparisonOperator: GreaterThanThreshold
       AlarmActions:
-      - !If [IsProd, !Ref 'TopicPagerDutyAlerts', !Ref 'AWS::NoValue']
+      - !If [IsProd, !Ref 'TopicSendEmail', !Ref 'AWS::NoValue']
       OKActions:
-      - !If [IsProd, !Ref 'TopicPagerDutyAlerts', !Ref 'AWS::NoValue']
+      - !If [IsProd, !Ref 'TopicSendEmail', !Ref 'AWS::NoValue']
 
   PaymentFailureQueueLengthAlert:
     Type: AWS::CloudWatch::Alarm
     Properties:
+      AlarmName: !Sub 'payment-failure-lambda-${Stage} Too many messages on the payment failure queue'
       AlarmDescription: Alarm if payment failure queue grows beyond 300
         message
       Namespace: AWS/SQS
@@ -181,6 +193,6 @@ Resources:
       Threshold: '300'
       ComparisonOperator: GreaterThanThreshold
       AlarmActions:
-      - !If [IsProd, !Ref 'TopicPagerDutyAlerts', !Ref 'AWS::NoValue']
+      - !If [IsProd, !Ref 'TopicSendEmail', !Ref 'AWS::NoValue']
       OKActions:
-      - !If [IsProd, !Ref 'TopicPagerDutyAlerts', !Ref 'AWS::NoValue']
+      - !If [IsProd, !Ref 'TopicSendEmail', !Ref 'AWS::NoValue']


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
We want to make it so that when alerts hit our inboxes, they have some useful information about why the alert has been triggered and what codebase it belongs to.

When we configure alerts, there is usually

-  a description associated with the alert.
- we can also define a readable name for the alert.
- we know what repo the alert belongs to

This information doesn't come through in the PagerDuty alerts and though I'm sure we could make the PagerDuty alerts more informative we seem to just be using PagerDuty to send emails. So this PR
- sends emails via the existing SNS topic rather than pagerduty
- adds alarm names
- updates alarm descriptions

The email address that should receive the alerts should be specified as a cloudformation parameter so to release this
### pre-merge
#### in CODE
- [x] try adding in an email topic and test alert in CODE, and see that the expected name and description arrive as an email (& tidy up after)
- [x] manually update the cloudformation & specify alarm email address param - payment failure lambda - then check it is possible to deploy the build with the changes
- [x] manually update the cloudformation & specify alarm email address param - eventbrite consents lambda - then check it is possible to deploy the build with the changes
- [x] manually update the cloudformation & specify alarm email address param - formstack baton consents lambda - then check it is possible to deploy the build with the changes
- [x] manually update the cloudformation & specify alarm email address param - formstack consents lambda - then check it is possible to deploy the build with the changes

#### in PROD (after PR approval)
- [x] manually update the cloudformation & specify alarm email address param - payment failure lambda
- [x] manually update the cloudformation & specify alarm email address param - eventbrite consents lambda
- [x] manually update the cloudformation & specify alarm email address param - formstack baton consents lambda
- [x] manually update the cloudformation & specify alarm email address param - formstack consents lambda
- [x] check that each these lambdas have deployed successfully after the merge 