### PR TITLE
stop sending ok alerts

### DIFF
--- a/payment-failure/cloud-formation.yaml
+++ b/payment-failure/cloud-formation.yaml
@@ -165,8 +165,6 @@ Resources:
       ComparisonOperator: GreaterThanThreshold
       AlarmActions:
       - !If [IsProd, !Ref 'TopicSendEmail', !Ref 'AWS::NoValue']
-      OKActions:
-      - !If [IsProd, !Ref 'TopicSendEmail', !Ref 'AWS::NoValue']
 
   PaymentFailureQueueLengthAlert:
     Type: AWS::CloudWatch::Alarm
@@ -184,6 +182,4 @@ Resources:
       Threshold: '300'
       ComparisonOperator: GreaterThanThreshold
       AlarmActions:
-      - !If [IsProd, !Ref 'TopicSendEmail', !Ref 'AWS::NoValue']
-      OKActions:
       - !If [IsProd, !Ref 'TopicSendEmail', !Ref 'AWS::NoValue']


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Every day at 10:15am we get an alert for 
`State Change:               INSUFFICIENT_DATA -> OK`

We don't care about this insufficient data -> ok transition.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
