### PR TITLE
Alarm on two eventbrite sync failures

### DIFF
--- a/eventbrite-consents/cloud-formation.yaml
+++ b/eventbrite-consents/cloud-formation.yaml
@@ -107,8 +107,8 @@ Resources:
       MetricName: Errors
       Statistic: Sum
       ComparisonOperator: GreaterThanOrEqualToThreshold
-      Threshold: '1'
-      Period: '60'
+      Threshold: '2'
+      Period: '36000' # 10 hours in seconds
       EvaluationPeriods: '1'
       AlarmActions:
       - !If [IsProd, !Ref 'TopicSendEmail', !Ref 'AWS::NoValue']


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Only trigger an alarm on two failures over a 10 hour period (the sync lambda fires every 4 hours).


## Why?

The alarm is going off too frequently for a single API failure. 

For a random, 'one off' failure we do not want to attempt to retry send since send email is not idempotent. We do not want to spam users. A more complicated retry mechanism that depends on the type off failure is not worth implementing right now.