### PR TITLE
Add sbt-dependency-graph plugin to fix Snyk build step

### DIFF
--- a/formstack-baton-requests/build.sbt
+++ b/formstack-baton-requests/build.sbt
@@ -43,7 +43,7 @@ addCompilerPlugin(
   "org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full
 )
 
-enablePlugins(RiffRaffArtifact, DependencyGraphPlugin)
+enablePlugins(RiffRaffArtifact)
 riffRaffPackageType := assembly.value
 riffRaffUploadArtifactBucket := Option("riffraff-artifact")
 riffRaffUploadManifestBucket := Option("riffraff-builds")

--- a/formstack-baton-requests/build.sbt
+++ b/formstack-baton-requests/build.sbt
@@ -43,7 +43,7 @@ addCompilerPlugin(
   "org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full
 )
 
-enablePlugins(RiffRaffArtifact)
+enablePlugins(RiffRaffArtifact, DependencyGraphPlugin)
 riffRaffPackageType := assembly.value
 riffRaffUploadArtifactBucket := Option("riffraff-artifact")
 riffRaffUploadManifestBucket := Option("riffraff-builds")

--- a/formstack-baton-requests/project/plugins.sbt
+++ b/formstack-baton-requests/project/plugins.sbt
@@ -1,2 +1,3 @@
 addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.0.0")
 addSbtPlugin("com.localytics" % "sbt-dynamodb" % "2.0.2")
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")


### PR DESCRIPTION
## What does this change?
The Snyk build step in Team City needs the sbt-dependency-graph plugin to run, otherwise it will fail and not send new and resolved vulnerabilities to the Snyk dashboard.

## How to test
This has been tested by temporarily changing the branch in the Snyk monitor build step to this branch and running the build in TC to see the build logs not throw any errors.

## How can we measure success?
New and resolved dependencies will be updated in the Snyk dashboard again.