### PR TITLE
Update Eventbrite consents lambda to handle invalid email addresses

### DIFF
--- a/eventbrite-consents/src/main/scala/com/gu/identity/eventbriteconsents/clients/IdentityClient.scala
+++ b/eventbrite-consents/src/main/scala/com/gu/identity/eventbriteconsents/clients/IdentityClient.scala
@@ -33,13 +33,13 @@ class IdentityClient(idapiUrl: String, idapiAccessToken: String) extends LazyLog
         } yield if (error.description.contains("Bad email format")) {
           logger.error("Invalid email address, could not process consents: " + emailAddress)
         } else {
-          throwRuntimeException
+          throwRuntimeException()
         }
       }
-      case _ => throwRuntimeException
+      case _ => throwRuntimeException()
     }
 
-    def throwRuntimeException: Nothing = {
+    def throwRuntimeException(): Nothing = {
       throw new RuntimeException(s"Unexpected response from idapi when syncing email $emailAddress $code $body")
     }
   }

--- a/eventbrite-consents/src/main/scala/com/gu/identity/eventbriteconsents/clients/IdentityClient.scala
+++ b/eventbrite-consents/src/main/scala/com/gu/identity/eventbriteconsents/clients/IdentityClient.scala
@@ -1,12 +1,16 @@
 package com.gu.identity.eventbriteconsents.clients
 
+import com.typesafe.scalalogging.LazyLogging
 import io.circe.generic.auto._
+import io.circe.parser._
 import io.circe.syntax._
 import scalaj.http.Http
 
 case class IdapiConsentUpdate(email: String, `set-consents`: Vector[String])
+case class IdapiErrorResponse(status: String, errors: List[IdapiError])
+case class IdapiError(message: String, description: String)
 
-class IdentityClient(idapiUrl: String, idapiAccessToken: String) {
+class IdentityClient(idapiUrl: String, idapiAccessToken: String) extends LazyLogging {
   def updateEventConsent(emailAddress: String): Unit = {
     val result = Http(s"$idapiUrl/consent-email")
       .headers(
@@ -16,6 +20,27 @@ class IdentityClient(idapiUrl: String, idapiAccessToken: String) {
       .postData(IdapiConsentUpdate(emailAddress, Vector("events")).asJson.noSpaces)
       .asString
 
-    if (result.code != 200) throw new RuntimeException(s"Unexpected response from idapi when syncing email $emailAddress ${result.code} ${result.body}")
+    if (result.code != 200) {
+      handleErrorResponse(result.code, result.body, emailAddress)
+    }
+  }
+
+  def handleErrorResponse(code: Int, body: String, emailAddress: String): Unit = {
+    parse(body).flatMap(_.as[IdapiErrorResponse]) match {
+      case Right(errorResponse: IdapiErrorResponse) => {
+        for {
+          error <- errorResponse.errors
+        } yield if (error.description.contains("Bad email format")) {
+          logger.error("Invalid email address, could not process consents: " + emailAddress)
+        } else {
+          throwRuntimeException
+        }
+      }
+      case _ => throwRuntimeException
+    }
+
+    def throwRuntimeException: Nothing = {
+      throw new RuntimeException(s"Unexpected response from idapi when syncing email $emailAddress $code $body")
+    }
   }
 }

--- a/eventbrite-consents/src/test/scala/com/gu/identity/eventbriteconsents/clients/IdentityClientTest.scala
+++ b/eventbrite-consents/src/test/scala/com/gu/identity/eventbriteconsents/clients/IdentityClientTest.scala
@@ -1,0 +1,45 @@
+package com.gu.identity.eventbriteconsents.clients
+
+import org.scalatest.FlatSpec
+import org.slf4j.{Logger => Underlying}
+import com.typesafe.scalalogging.Logger
+import org.mockito.Mockito._
+
+class IdentityClientTest extends FlatSpec {
+
+  def identityClient(mocked: Underlying): IdentityClient = {
+    new IdentityClient("idapiUrl", "idapiToken") {
+      override lazy val logger = Logger(mocked)
+    }
+  }
+
+  val mockedLogger = mock(classOf[Underlying])
+  val emailAddress = "someEmailAddress"
+  val invalidEmailResponse = "{\"status\":\"error\",\"errors\":[{\"message\":\"Bad Request\",\"description\":\"Bad email format, Error(Registration Error,There was an error with your registration.,None)\"}]}"
+  val someOtherErrorResponse = "{\"status\":\"error\",\"errors\":[{\"message\":\"Bad Request\",\"description\":\"Something else bad happened\"}]}"
+  val nonJsonErrorResponse = "some other error message"
+
+  "handleErrorResponse" should "log invalid email errors" in {
+    when(mockedLogger.isErrorEnabled()).thenReturn(true)
+
+    identityClient(mockedLogger).handleErrorResponse(400, invalidEmailResponse, emailAddress)
+    verify(mockedLogger).error("Invalid email address, could not process consents: " + emailAddress)
+  }
+
+  "handleErrorResponse" should "throw runtime exception for other errors" in {
+    when(mockedLogger.isErrorEnabled()).thenReturn(true)
+
+    assertThrows[RuntimeException] {
+      identityClient(mockedLogger).handleErrorResponse(400, someOtherErrorResponse, emailAddress)
+    }
+  }
+
+  "handleErrorResponse" should "throw runtime exception for non-json error responses" in {
+    when(mockedLogger.isErrorEnabled()).thenReturn(true)
+
+    assertThrows[RuntimeException] {
+      identityClient(mockedLogger).handleErrorResponse(400, nonJsonErrorResponse, emailAddress)
+    }
+  }
+
+}


### PR DESCRIPTION
## What does this change?
When a user submits an invalid email address, log the error rather than throwing a Runtime exception which terminates the application. 

We were getting alerts about lambda errors because a user had entered an invalid email address. We do not want this error to terminate the application as it means other emails in the batch do not get processed, so we log the error instead and throw an exception for any other scenario.

## How to test
There are unit tests.

## How can we measure success?
Email consent batches should complete successfully if one email address in the batch is invalid and we should still be alerted to any other errors.