### PR TITLE
Delay failure emails by 5 minutes to ensure emails are sent by braze

### DIFF
--- a/payment-failure/cloud-formation.yaml
+++ b/payment-failure/cloud-formation.yaml
@@ -124,6 +124,7 @@ Resources:
       RedrivePolicy:
         deadLetterTargetArn: !GetAtt PaymentFailureDeadLetterQueue.Arn
         maxReceiveCount: 5
+      DelaySeconds: 300
 
   PaymentFailureSqsWriteRole:
     Type: AWS::SQS::QueuePolicy

--- a/payment-failure/cloud-formation.yaml
+++ b/payment-failure/cloud-formation.yaml
@@ -124,7 +124,7 @@ Resources:
       RedrivePolicy:
         deadLetterTargetArn: !GetAtt PaymentFailureDeadLetterQueue.Arn
         maxReceiveCount: 5
-      DelaySeconds: 300
+      DelaySeconds: 120
 
   PaymentFailureSqsWriteRole:
     Type: AWS::SQS::QueuePolicy


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Delay the failure lambda ingest from SQS by 5 minutes to ensure emails sent via Braze are sent to users.

## Why?

Braze won't always send emails for newly created accounts.  (see https://www.braze.com/docs/help/best_practices/race_conditions/ )
Braze will return success responses even if the email fails to be sent. 
