### PR TITLE
use java correto 8. Java 8 is getting deprecated

### DIFF
--- a/eventbrite-consents/cloud-formation.yaml
+++ b/eventbrite-consents/cloud-formation.yaml
@@ -72,7 +72,7 @@ Resources:
           syncFrequencyHours: !FindInMap [SyncFrequencyMap, values, syncFrequencyHours]
           isDebug: !FindInMap [IsDebugMap, !Ref Stage, value]
       Handler: com.gu.identity.eventbriteconsents.Lambda::handler
-      Runtime: java8
+      Runtime: java8.al2
       CodeUri:
         Bucket: identity-lambda
         Key: !Sub identity/${Stage}/eventbrite-consents-lambda/main.jar

--- a/eventbrite-consents/cloud-formation.yaml
+++ b/eventbrite-consents/cloud-formation.yaml
@@ -57,7 +57,7 @@ Resources:
   EventbriteConsentsLambda:
     Type: AWS::Serverless::Function
     Properties:
-      MemorySize: 512
+      MemorySize: 1024
       FunctionName: !Sub EventbriteConsentsLambda-${Stage}
       Timeout: 120
       Description: Lambda to send email to user who has signed up to a newsletter via Eventbrite

--- a/formstack-baton-requests/cloud-formation.yaml
+++ b/formstack-baton-requests/cloud-formation.yaml
@@ -144,7 +144,7 @@ Resources:
           RESULTS_BUCKET: !Ref ResultsBucket
           RESULTS_PATH: !Sub formstack-results/${Stage}
           STATE_MACHINE_ARN: !Ref FormstackSar
-      MemorySize: 384
+      MemorySize: 1024
       Runtime: java8.al2
       Timeout: 120
       VpcConfig:
@@ -276,7 +276,7 @@ Resources:
           BCRYPT_SALT_PATH: !Ref BcryptSaltPath
           SUBMISSION_TABLE_NAME: !Ref SubmissionsTableName
           LAST_UPDATED_TABLE_NAME: !Ref LastUpdatedTableName
-      MemorySize: 384
+      MemorySize: 1024
       Runtime: java8.al2
       Timeout: 900
       VpcConfig:
@@ -349,7 +349,7 @@ Resources:
           RESULTS_BUCKET: !Ref ResultsBucket
           RESULTS_PATH: !Sub formstack-results/${Stage}
           STATE_MACHINE_ARN: !Ref FormstackRer
-      MemorySize: 384
+      MemorySize: 1024
       Runtime: java8.al2
       Timeout: 120
       VpcConfig:
@@ -446,7 +446,7 @@ Resources:
           BCRYPT_SALT_PATH: !Ref BcryptSaltPath
           SUBMISSION_TABLE_NAME: !Ref SubmissionsTableName
           LAST_UPDATED_TABLE_NAME: !Ref LastUpdatedTableName
-      MemorySize: 384
+      MemorySize: 1024
       Runtime: java8.al2
       Timeout: 900
       VpcConfig:

--- a/formstack-baton-requests/cloud-formation.yaml
+++ b/formstack-baton-requests/cloud-formation.yaml
@@ -145,7 +145,7 @@ Resources:
           RESULTS_PATH: !Sub formstack-results/${Stage}
           STATE_MACHINE_ARN: !Ref FormstackSar
       MemorySize: 384
-      Runtime: java8
+      Runtime: java8.al2
       Timeout: 120
       VpcConfig:
         SecurityGroupIds:
@@ -277,7 +277,7 @@ Resources:
           SUBMISSION_TABLE_NAME: !Ref SubmissionsTableName
           LAST_UPDATED_TABLE_NAME: !Ref LastUpdatedTableName
       MemorySize: 384
-      Runtime: java8
+      Runtime: java8.al2
       Timeout: 900
       VpcConfig:
         SecurityGroupIds:
@@ -350,7 +350,7 @@ Resources:
           RESULTS_PATH: !Sub formstack-results/${Stage}
           STATE_MACHINE_ARN: !Ref FormstackRer
       MemorySize: 384
-      Runtime: java8
+      Runtime: java8.al2
       Timeout: 120
       VpcConfig:
         SecurityGroupIds:
@@ -447,7 +447,7 @@ Resources:
           SUBMISSION_TABLE_NAME: !Ref SubmissionsTableName
           LAST_UPDATED_TABLE_NAME: !Ref LastUpdatedTableName
       MemorySize: 384
-      Runtime: java8
+      Runtime: java8.al2
       Timeout: 900
       VpcConfig:
         SecurityGroupIds:
@@ -545,7 +545,7 @@ Resources:
           SUBMISSION_TABLE_NAME: !Ref SubmissionsTableName
           LAST_UPDATED_TABLE_NAME: !Ref LastUpdatedTableName
       MemorySize: 1024
-      Runtime: java8
+      Runtime: java8.al2
       Timeout: 900
       VpcConfig:
         SecurityGroupIds:

--- a/formstack-consents/cloud-formation.yaml
+++ b/formstack-consents/cloud-formation.yaml
@@ -41,7 +41,7 @@ Resources:
   FormstackConsentsLambda:
     Type: AWS::Serverless::Function
     Properties:
-      MemorySize: 512
+      MemorySize: 1024
       FunctionName: !Sub FormstackConsentsLambda-${Stage}
       Timeout: 120
       Description: Lambda to send email to user who has signed up to a newsletter via Formstack

--- a/formstack-consents/cloud-formation.yaml
+++ b/formstack-consents/cloud-formation.yaml
@@ -51,7 +51,7 @@ Resources:
           idapiAccessToken: !Sub ${IdentityAPIKey}
           formstackSharedSecret: !Sub ${FormstackSharedSecret}
       Handler: com.gu.identity.formstackconsents.Lambda::handler
-      Runtime: java8
+      Runtime: java8.al2
       CodeUri:
         Bucket: identity-lambda
         Key: !Sub identity/${Stage}/formstack-consents-lambda/main.jar

--- a/payment-failure/cloud-formation.yaml
+++ b/payment-failure/cloud-formation.yaml
@@ -102,7 +102,7 @@ Resources:
       FunctionName: !Sub PaymentFailureLambda-${Stage}
       Handler: com.gu.identity.paymentfailure.Lambda::handler
       Role: !GetAtt PaymentFailureLambdaRole.Arn
-      Runtime: java8
+      Runtime: java8.al2
       Timeout: 30
       MemorySize: 512
 

--- a/payment-failure/cloud-formation.yaml
+++ b/payment-failure/cloud-formation.yaml
@@ -104,7 +104,7 @@ Resources:
       Role: !GetAtt PaymentFailureLambdaRole.Arn
       Runtime: java8.al2
       Timeout: 30
-      MemorySize: 512
+      MemorySize: 1024
 
   PaymentFailureLambdaLogGroup:
     Type: AWS::Logs::LogGroup


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

use java Corret0 8. Java 8 is getting removed (any lambdas on Java 8 are getting automatically migrated to Corretto 8 by 27 September)

see https://aws.amazon.com/blogs/compute/announcing-migration-of-the-java-8-runtime-in-aws-lambda-to-amazon-corretto/

and

https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html

