### PR TITLE
Increase connection timeouts for Eventbrite API request

### DIFF
--- a/eventbrite-consents/src/main/scala/com/gu/identity/eventbriteconsents/clients/EventbriteClient.scala
+++ b/eventbrite-consents/src/main/scala/com/gu/identity/eventbriteconsents/clients/EventbriteClient.scala
@@ -27,8 +27,8 @@ class EventbriteClient {
         "changed_since" -> formattedLastRun,
         "continuation" -> continuationToken
       )
+      .timeout(2000, 10000)
       .asString
-
 
     if (response.code == 200) {
       parse(response.body).flatMap(_.as[EventbriteResponse]) match {


### PR DESCRIPTION
## What does this change?
This doubles the (default) socket connection and read timeouts for the Eventbrite consents Lambda. We are getting socket timeout exceptions in the Lambda logs because the request to the Eventbrite API is taking longer than the default timeout.
