### PR TITLE
fix log4j version dependency

### DIFF
--- a/formstack-consents/build.sbt
+++ b/formstack-consents/build.sbt
@@ -4,7 +4,7 @@ version := "0.1"
 
 scalaVersion := "2.12.8"
 val circeVersion = "0.11.0"
-val log4jVersion = log4jVersion
+val log4jVersion = "2.16.0"
 
 libraryDependencies ++= Seq(
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.0",


### PR DESCRIPTION
## What does this change?

The variable mistakenly references itself introduced here
https://github.com/guardian/identity-processes/pull/83/files#diff-d31fea3af2e60090417cffbd256efdf44f52df2868a165c414a9a04c2d3f8f99R7