### PR TITLE
Remove dynamodb local

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea/
+target/

--- a/formstack-baton-requests/build.sbt
+++ b/formstack-baton-requests/build.sbt
@@ -1,3 +1,5 @@
+import sys.process._
+
 name := "formstack-baton-requests"
 
 version := "0.1"
@@ -37,11 +39,6 @@ assembly / assemblyMergeStrategy := {
     oldStrategy(x)
 }
 
-startDynamoDBLocal := startDynamoDBLocal.dependsOn(Test / compile).value
-Test / test := (Test / test).dependsOn(startDynamoDBLocal).value
-Test / testOnly := (Test / testOnly).dependsOn(startDynamoDBLocal).evaluated
-Test / testOptions += dynamoDBLocalTestCleanup.value
-
 addCompilerPlugin(
   "org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full
 )
@@ -51,3 +48,11 @@ riffRaffPackageType := assembly.value
 riffRaffUploadArtifactBucket := Option("riffraff-artifact")
 riffRaffUploadManifestBucket := Option("riffraff-builds")
 riffRaffArtifactResources += (file("cloud-formation.yaml") -> "formstack-baton-requests-cfn/cloud-formation.yaml")
+
+Test / testOptions += Tests.Setup { () =>
+  "./localenv/start-dependencies.sh".!
+}
+
+Test / testOptions += Tests.Cleanup { () =>
+  "./localenv/stop-dependencies.sh".!
+}

--- a/formstack-baton-requests/localenv/docker-compose.yaml
+++ b/formstack-baton-requests/localenv/docker-compose.yaml
@@ -1,0 +1,5 @@
+version: "3.3"
+services:
+  dynamodb-local:
+    image: "amazon/dynamodb-local:latest"
+    ports: ["8000:8000"]

--- a/formstack-baton-requests/localenv/start-dependencies.sh
+++ b/formstack-baton-requests/localenv/start-dependencies.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -ex
+cd `dirname $0`
+
+./stop-dependencies.sh
+docker-compose -p formstack-baton-requests up --force-recreate -d

--- a/formstack-baton-requests/localenv/stop-dependencies.sh
+++ b/formstack-baton-requests/localenv/stop-dependencies.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -ex
+cd `dirname $0`
+
+docker-compose -p formstack-baton-requests stop

--- a/formstack-baton-requests/project/plugins.sbt
+++ b/formstack-baton-requests/project/plugins.sbt
@@ -1,3 +1,2 @@
 addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.0.0")
-addSbtPlugin("com.localytics" % "sbt-dynamodb" % "2.0.2")
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")


### PR DESCRIPTION
## What does this change?

Replace sbt-dynamodb with dockerised dynamodb

## Why?

- sbt-dynamodb is no longer maintained
- @vlbee says sbt-dynamodb uses a vulnerable version of log4j