### PR TITLE
Run UpdateDynamoHandler locally without lambda timeout retries

### DIFF
--- a/formstack-baton-requests/build.sbt
+++ b/formstack-baton-requests/build.sbt
@@ -56,3 +56,19 @@ Test / testOptions += Tests.Setup { () =>
 Test / testOptions += Tests.Cleanup { () =>
   "./localenv/stop-dependencies.sh".!
 }
+
+Compile / run / fork := true
+Compile / mainClass := Some("com.gu.identity.formstackbatonrequests.LocalRun")
+Compile / run / mainClass := Some("com.gu.identity.formstackbatonrequests.LocalRun")
+run / javaOptions  += "-agentlib:jdwp=transport=dt_socket,server=n,address=localhost:5005,suspend=y"
+run / envVars := Map(
+  "BCRYPT_SALT_PATH" ->	"/identity/formstack-baton-requests/bcrypt-salt",
+  "ENCRYPTION_PASSWORD_PATH" ->	"/identity/formstack-baton-requests/encryption-password",
+  "FORMSTACK_ACCOUNT_ONE_TOKEN_PATH" ->	"/identity/formstack-baton-requests/formstack-account-one-token",
+  "FORMSTACK_ACCOUNT_TWO_TOKEN_PATH" ->	"/identity/formstack-baton-requests/formstack-account-two-token",
+  "LAST_UPDATED_TABLE_NAME" ->	"formstack-submissions-last-updated",
+  "RESULTS_BUCKET" ->	"gu-baton-results",
+  "RESULTS_PATH" ->	"formstack-results/PROD",
+  "STAGE" ->	"PROD",
+  "SUBMISSION_TABLE_NAME" ->	"formstack-submission-ids",
+)

--- a/formstack-baton-requests/build.sbt
+++ b/formstack-baton-requests/build.sbt
@@ -60,7 +60,7 @@ Test / testOptions += Tests.Cleanup { () =>
 Compile / run / fork := true
 Compile / mainClass := Some("com.gu.identity.formstackbatonrequests.LocalRun")
 Compile / run / mainClass := Some("com.gu.identity.formstackbatonrequests.LocalRun")
-run / javaOptions  += "-agentlib:jdwp=transport=dt_socket,server=n,address=localhost:5005,suspend=y"
+// run / javaOptions  += "-agentlib:jdwp=transport=dt_socket,server=n,address=localhost:5005,suspend=y"
 run / envVars := Map(
   "BCRYPT_SALT_PATH" ->	"/identity/formstack-baton-requests/bcrypt-salt",
   "ENCRYPTION_PASSWORD_PATH" ->	"/identity/formstack-baton-requests/encryption-password",

--- a/formstack-baton-requests/src/main/scala/com/gu/identity/formstackbatonrequests/Handler.scala
+++ b/formstack-baton-requests/src/main/scala/com/gu/identity/formstackbatonrequests/Handler.scala
@@ -143,10 +143,8 @@ object LocalRun extends App {
       count = FormstackService.resultsPerPage,
       timeOfStart = LocalDateTime.now,
     )
-//
-//  println(Option(System.getenv("RESULTS_BUCKET")))
+
   val updateConfig = FormstackConfig.getPerformHandlerConfig
-//  println(updateConfig)
   val updateLambda = UpdateDynamoHandler(Dynamo(), S3, FormstackService, updateConfig)
   val streams = requestStreams(updateDynamoRequest)
   updateLambda.handleRequest(streams.inputStream, streams.outputStream, null)

--- a/formstack-baton-requests/src/main/scala/com/gu/identity/formstackbatonrequests/services/DynamoUpdateService.scala
+++ b/formstack-baton-requests/src/main/scala/com/gu/identity/formstackbatonrequests/services/DynamoUpdateService.scala
@@ -67,10 +67,8 @@ case class DynamoUpdateService(
         val errors = formResults.collect { case Left(err) => err }
         if (errors.nonEmpty) {
           Left(new Exception(errors.toString))
-        } else if (count < response.total & context.getRemainingTimeInMillis > 300000) {
-          updateSubmissionsTable(formsPage + 1, lastUpdate, count + FormstackService.resultsPerPage, token, context)
         } else if (count < response.total) {
-          Right(UpdateStatus(completed = false, Some(formsPage + 1), Some(count + FormstackService.resultsPerPage), token))
+          updateSubmissionsTable(formsPage + 1, lastUpdate, count + FormstackService.resultsPerPage, token, context)
         } else Right(UpdateStatus(completed = true, None, None, token))
     }
   }

--- a/formstack-baton-requests/src/main/scala/com/gu/identity/formstackbatonrequests/services/FormstackService.scala
+++ b/formstack-baton-requests/src/main/scala/com/gu/identity/formstackbatonrequests/services/FormstackService.scala
@@ -24,6 +24,7 @@ object FormstackService extends FormstackRequestService with LazyLogging {
 
   override def accountFormsForGivenPage(page: Int, accountToken: FormstackAccountToken): Either[Throwable, FormsResponse] = {
     val response = Http(s"https://www.formstack.com/api/v2/form.json")
+      .timeout(5000, 60000)
       .header("Authorization", accountToken.secret)
       .params(
         Seq(
@@ -45,6 +46,7 @@ object FormstackService extends FormstackRequestService with LazyLogging {
     encryptionPassword: String,
     accountToken: FormstackAccountToken): Either[Throwable, FormSubmissions] = {
     val response = Http(s"https://www.formstack.com/api/v2/form/$formId/submission.json")
+      .timeout(5000, 60000)
       .headers(
         Seq(
           ("Authorization", accountToken.secret),
@@ -81,6 +83,7 @@ object FormstackService extends FormstackRequestService with LazyLogging {
     submissionIdEmails.traverse { submissionIdEmail =>
       val response =
         Http(s"https://www.formstack.com/api/v2/submission/${submissionIdEmail.submissionId}.json")
+          .timeout(5000, 60000)
           .header("Authorization", accountToken.secret)
           .param("encryption_password", encryptionPassword)
           .asString
@@ -101,6 +104,7 @@ object FormstackService extends FormstackRequestService with LazyLogging {
       val labelsAndValuesOrError = submission.data.map { responseValues =>
         val fieldId = responseValues.field
         val response = Http(s"https://www.formstack.com/api/v2/field/$fieldId")
+          .timeout(5000, 60000)
           .header("Authorization", accountToken.secret)
           .asString
 
@@ -135,6 +139,7 @@ object FormstackService extends FormstackRequestService with LazyLogging {
       val token = tokens.find( token => token.account == submissionIdEmail.accountNumber).get
       val response =
         Http(s"https://www.formstack.com/api/v2/submission/${submissionIdEmail.submissionId}.json")
+          .timeout(5000, 60000)
           .method("DELETE")
           .header("Authorization", token.secret)
           .asString


### PR DESCRIPTION
Run UpdateDynamoHandler locally without lambda timeout retries

uncomment in build.sbt to debug with intellij as debugging server on port 5005
```
// run / javaOptions += "-agentlib:jdwp=transport=dt_socket,server=n,address=localhost:5005,suspend=y"
```

To run

```
cd formstack-baton-requests/
sbt
```

In sbt shell

```
run
```