### PR TITLE
fix: try increasing page size so we make fewer total requests

### DIFF
--- a/formstack-baton-requests/src/main/scala/com/gu/identity/formstackbatonrequests/rer/FormstackRerHandler.scala
+++ b/formstack-baton-requests/src/main/scala/com/gu/identity/formstackbatonrequests/rer/FormstackRerHandler.scala
@@ -24,7 +24,7 @@ case class FormstackRerHandler(s3Client: S3Client, lambdaClient: StepFunctionCli
       "formstack",
       None,
       1,
-      FormstackService.resultsPerPage,
+      FormstackService.formResultsPerPage,
       LocalDateTime.now
     )
 

--- a/formstack-baton-requests/src/main/scala/com/gu/identity/formstackbatonrequests/sar/FormstackSarHandler.scala
+++ b/formstack-baton-requests/src/main/scala/com/gu/identity/formstackbatonrequests/sar/FormstackSarHandler.scala
@@ -24,7 +24,7 @@ case class FormstackSarHandler(s3Client: S3Client, lambdaClient: StepFunctionCli
       "formstack",
       None,
       1,
-      FormstackService.resultsPerPage,
+      FormstackService.formResultsPerPage,
       LocalDateTime.now
     )
 

--- a/formstack-baton-requests/src/main/scala/com/gu/identity/formstackbatonrequests/services/DynamoUpdateService.scala
+++ b/formstack-baton-requests/src/main/scala/com/gu/identity/formstackbatonrequests/services/DynamoUpdateService.scala
@@ -68,9 +68,9 @@ case class DynamoUpdateService(
         if (errors.nonEmpty) {
           Left(new Exception(errors.toString))
         } else if (count < response.total & context.getRemainingTimeInMillis > 300000) {
-          updateSubmissionsTable(formsPage + 1, lastUpdate, count + FormstackService.resultsPerPage, token, context)
+          updateSubmissionsTable(formsPage + 1, lastUpdate, count + FormstackService.formResultsPerPage, token, context)
         } else if (count < response.total) {
-          Right(UpdateStatus(completed = false, Some(formsPage + 1), Some(count + FormstackService.resultsPerPage), token))
+          Right(UpdateStatus(completed = false, Some(formsPage + 1), Some(count + FormstackService.formResultsPerPage), token))
         } else Right(UpdateStatus(completed = true, None, None, token))
     }
   }

--- a/formstack-baton-requests/src/main/scala/com/gu/identity/formstackbatonrequests/services/FormstackService.scala
+++ b/formstack-baton-requests/src/main/scala/com/gu/identity/formstackbatonrequests/services/FormstackService.scala
@@ -20,7 +20,7 @@ case class FormstackDecryptionError(message: String) extends Throwable
 
 object FormstackService extends FormstackRequestService with LazyLogging {
 
-  val resultsPerPage = 25
+  val resultsPerPage = 100
 
   override def accountFormsForGivenPage(page: Int, accountToken: FormstackAccountToken): Either[Throwable, FormsResponse] = {
     val response = Http(s"https://www.formstack.com/api/v2/form.json")

--- a/formstack-baton-requests/src/main/scala/com/gu/identity/formstackbatonrequests/services/FormstackService.scala
+++ b/formstack-baton-requests/src/main/scala/com/gu/identity/formstackbatonrequests/services/FormstackService.scala
@@ -20,7 +20,8 @@ case class FormstackDecryptionError(message: String) extends Throwable
 
 object FormstackService extends FormstackRequestService with LazyLogging {
 
-  val resultsPerPage = 100
+  val formResultsPerPage = 25
+  val submissionResultsPerPage = 100
 
   override def accountFormsForGivenPage(page: Int, accountToken: FormstackAccountToken): Either[Throwable, FormsResponse] = {
     val response = Http(s"https://www.formstack.com/api/v2/form.json")
@@ -28,7 +29,7 @@ object FormstackService extends FormstackRequestService with LazyLogging {
       .params(
         Seq(
           ("page", page.toString),
-          ("per_page", resultsPerPage.toString)
+          ("per_page", formResultsPerPage.toString)
         )
       ).asString
 
@@ -54,7 +55,7 @@ object FormstackService extends FormstackRequestService with LazyLogging {
       .params(
         Seq(
           ("page", page.toString),
-          ("per_page", resultsPerPage.toString),
+          ("per_page", submissionResultsPerPage.toString),
           ("data", "true"),
           ("expand_data", "true"),
           ("sort", "DESC"),

--- a/formstack-baton-requests/src/test/scala/com/gu/identity/formstackbatonrequests/CirceCodecsSpec.scala
+++ b/formstack-baton-requests/src/test/scala/com/gu/identity/formstackbatonrequests/CirceCodecsSpec.scala
@@ -210,7 +210,7 @@ class CirceCodecsSpec extends FreeSpec with Matchers {
         dataProvider = "formstack",
         accountNumber = Some(1),
         formPage = 1,
-        count = 25,
+        count = 100,
         timeOfStart = LocalDateTime.of(2020, 2, 1, 0, 0)
       )
 
@@ -222,7 +222,7 @@ class CirceCodecsSpec extends FreeSpec with Matchers {
           |"dataProvider": "formstack",
           |"accountNumber": 1,
           |"formPage": 1,
-          |"count": 25,
+          |"count": 100,
           |"timeOfStart": "2020-02-01T00:00"
           |}
           |""".stripMargin
@@ -238,7 +238,7 @@ class CirceCodecsSpec extends FreeSpec with Matchers {
         dataProvider = "formstack",
         accountNumber = None,
         formPage = 1,
-        count = 25,
+        count = 100,
         timeOfStart = LocalDateTime.of(2020, 2, 1, 0, 0)
       )
 
@@ -249,7 +249,7 @@ class CirceCodecsSpec extends FreeSpec with Matchers {
           |"subjectEmail": "testSubjectEmail",
           |"dataProvider": "formstack",
           |"formPage": 1,
-          |"count": 25,
+          |"count": 100,
           |"timeOfStart": "2020-02-01T00:00"
           |}
           |""".stripMargin

--- a/formstack-baton-requests/src/test/scala/com/gu/identity/formstackbatonrequests/CirceCodecsSpec.scala
+++ b/formstack-baton-requests/src/test/scala/com/gu/identity/formstackbatonrequests/CirceCodecsSpec.scala
@@ -210,7 +210,7 @@ class CirceCodecsSpec extends FreeSpec with Matchers {
         dataProvider = "formstack",
         accountNumber = Some(1),
         formPage = 1,
-        count = 100,
+        count = 25,
         timeOfStart = LocalDateTime.of(2020, 2, 1, 0, 0)
       )
 
@@ -222,7 +222,7 @@ class CirceCodecsSpec extends FreeSpec with Matchers {
           |"dataProvider": "formstack",
           |"accountNumber": 1,
           |"formPage": 1,
-          |"count": 100,
+          |"count": 25,
           |"timeOfStart": "2020-02-01T00:00"
           |}
           |""".stripMargin
@@ -238,7 +238,7 @@ class CirceCodecsSpec extends FreeSpec with Matchers {
         dataProvider = "formstack",
         accountNumber = None,
         formPage = 1,
-        count = 100,
+        count = 25,
         timeOfStart = LocalDateTime.of(2020, 2, 1, 0, 0)
       )
 
@@ -249,7 +249,7 @@ class CirceCodecsSpec extends FreeSpec with Matchers {
           |"subjectEmail": "testSubjectEmail",
           |"dataProvider": "formstack",
           |"formPage": 1,
-          |"count": 100,
+          |"count": 25,
           |"timeOfStart": "2020-02-01T00:00"
           |}
           |""".stripMargin


### PR DESCRIPTION
## What does this change?
Increases the number of results we ask for per page to 100, hopefully reducing the possibility of a timeout as we are making fewer requests to Formstack