### PR TITLE
Add tests for updateSubmissionsTable

### DIFF
--- a/formstack-baton-requests/build.sbt
+++ b/formstack-baton-requests/build.sbt
@@ -25,6 +25,7 @@ libraryDependencies ++= Seq(
   "io.circe" %% "circe-parser" % circeVersion,
   "io.circe" %% "circe-generic" % circeVersion,
   "org.scalatest" %% "scalatest" % "3.0.5" % "test",
+  "org.scalamock" %% "scalamock" % "5.1.0" % "test",
   "com.github.t3hnar" %% "scala-bcrypt" % "3.1"
 )
 

--- a/formstack-baton-requests/src/main/scala/com/gu/identity/formstackbatonrequests/services/DynamoUpdateService.scala
+++ b/formstack-baton-requests/src/main/scala/com/gu/identity/formstackbatonrequests/services/DynamoUpdateService.scala
@@ -69,7 +69,11 @@ case class DynamoUpdateService(
         } else if (count < response.total & context.getRemainingTimeInMillis > 300000) {
           updateSubmissionsTable(formsPage + 1, lastUpdate, count + FormstackService.formResultsPerPage, token, context)
         } else if (count < response.total) {
-          Right(UpdateStatus(completed = false, Some(formsPage + 1), Some(count + FormstackService.formResultsPerPage), token))
+          val nextPage = formsPage + 1
+          val formCount = count + FormstackService.formResultsPerPage
+          logger.info(s"Approaching execution time limit, stopping at page ${nextPage}, form count: ${formCount}")
+
+          Right(UpdateStatus(completed = false, Some(nextPage), Some(formCount), token))
         } else Right(UpdateStatus(completed = true, None, None, token))
     }
   }

--- a/formstack-baton-requests/src/main/scala/com/gu/identity/formstackbatonrequests/services/DynamoUpdateService.scala
+++ b/formstack-baton-requests/src/main/scala/com/gu/identity/formstackbatonrequests/services/DynamoUpdateService.scala
@@ -53,7 +53,6 @@ case class DynamoUpdateService(
     }
   }
 
-
   def updateSubmissionsTable(formsPage: Int, lastUpdate: SubmissionTableUpdateDate, count: Int, token: FormstackAccountToken, context: Context): Either[Throwable, UpdateStatus] = {
     logger.info(s"----------Getting page $formsPage of forms.----------")
     formstackClient.accountFormsForGivenPage(formsPage, token) match {

--- a/formstack-baton-requests/src/main/scala/com/gu/identity/formstackbatonrequests/services/DynamoUpdateService.scala
+++ b/formstack-baton-requests/src/main/scala/com/gu/identity/formstackbatonrequests/services/DynamoUpdateService.scala
@@ -64,14 +64,18 @@ case class DynamoUpdateService(
           writeSubmissions(form, lastUpdate, token = token)
         }
         val errors = formResults.collect { case Left(err) => err }
+
+        val formCount = count + FormstackService.formResultsPerPage
+        val nextPage = formsPage + 1
+
         if (errors.nonEmpty) {
           Left(new Exception(errors.toString))
         } else if (count < response.total & context.getRemainingTimeInMillis > 300000) {
-          updateSubmissionsTable(formsPage + 1, lastUpdate, count + FormstackService.formResultsPerPage, token, context)
+          logger.info(s"Continuing to page/formCount: ${nextPage}/${formCount}")
+
+          updateSubmissionsTable(nextPage, lastUpdate, formCount, token, context)
         } else if (count < response.total) {
-          val nextPage = formsPage + 1
-          val formCount = count + FormstackService.formResultsPerPage
-          logger.info(s"Approaching execution time limit, stopping at page ${nextPage}, form count: ${formCount}")
+          logger.info(s"Approaching execution time limit, stopping at page/formCount: ${nextPage}/${formCount}")
 
           Right(UpdateStatus(completed = false, Some(nextPage), Some(formCount), token))
         } else Right(UpdateStatus(completed = true, None, None, token))

--- a/formstack-baton-requests/src/test/scala/com/gu/identity/formstackbatonrequests/services/FormstackServiceStub.scala
+++ b/formstack-baton-requests/src/test/scala/com/gu/identity/formstackbatonrequests/services/FormstackServiceStub.scala
@@ -42,7 +42,6 @@ object FormstackServiceStub {
 
   val genericFormstackError = Left(new Exception("Formstack API error"))
 
-
   def withFailedResponse = new FormstackServiceStub(genericFormstackError, genericFormstackError, genericFormstackError, genericFormstackError)
   def withSuccessResponse = new FormstackServiceStub(accountFormsForGivenPageSuccess, formSubmissionsForGivenPageSuccess, submissionDataSuccess, deleteDataSuccess)
 }

--- a/formstack-baton-requests/src/test/scala/com/gu/identity/formstackbatonrequests/services/FormstackServiceStub.scala
+++ b/formstack-baton-requests/src/test/scala/com/gu/identity/formstackbatonrequests/services/FormstackServiceStub.scala
@@ -40,8 +40,9 @@ object FormstackServiceStub {
   val deleteDataSuccess =
     Right(List(SubmissionDeletionReponse(1)))
 
-  val genericFormstackError = Left(new Exception("Formstack API error"))
+  val genericFormstackError = new Exception("Formstack API error")
+  val genericFormstackErrorLeft = Left(genericFormstackError)
 
-  def withFailedResponse = new FormstackServiceStub(genericFormstackError, genericFormstackError, genericFormstackError, genericFormstackError)
+  def withFailedResponse = new FormstackServiceStub(genericFormstackErrorLeft, genericFormstackErrorLeft, genericFormstackErrorLeft, genericFormstackErrorLeft)
   def withSuccessResponse = new FormstackServiceStub(accountFormsForGivenPageSuccess, formSubmissionsForGivenPageSuccess, submissionDataSuccess, deleteDataSuccess)
 }


### PR DESCRIPTION
## What does this change?

This change includes tests for the updateSubmissionsTable function to ensure it (a) behaves as expected and (b) enables future refactoring.

## How to test

New tests will run in CI without modification of the test setup.

## How can we measure success?

Passing tests!

Related: https://github.com/guardian/identity-processes/pull/93

