### PR TITLE
Remove recursion from writing pages

### DIFF
--- a/formstack-baton-requests/src/test/scala/com/gu/identity/formstackbatonrequests/services/DynamoUpdateServiceSpec.scala
+++ b/formstack-baton-requests/src/test/scala/com/gu/identity/formstackbatonrequests/services/DynamoUpdateServiceSpec.scala
@@ -81,7 +81,6 @@ class DynamoUpdateServiceSpec
         token = dummyToken,
         context = mockContext
       )
-
       statusUpdate.right.value shouldBe expectedUpdateStatus
     }
 


### PR DESCRIPTION
## What does this change?

This PR removes recursion from the process of getting form submissions from Formstack and writing them to DynamoDb. This simplifies the code and opens a path to parallelising operations that currently can timeout when run in sequence.

## How to test

Run the project tests!

## How can we measure success?

No regressions in the tests passing.