### PR TITLE
Add skip for password protected forms

### DIFF
--- a/formstack-baton-requests/src/main/scala/com/gu/identity/formstackbatonrequests/services/FormstackService.scala
+++ b/formstack-baton-requests/src/main/scala/com/gu/identity/formstackbatonrequests/services/FormstackService.scala
@@ -69,7 +69,8 @@ object FormstackService extends FormstackRequestService with LazyLogging {
 
     /* There are a couple of forms that the Formstack API can't seem to decrypt. There seems to be no way around this
      *  so we capture this specific error and skip these forms. */
-    if(response.body.contains("An error occurred while decrypting the submissions"))
+    // We also skip responses from Formstack that contain "Incorrect password". These are undocumented, and we do not know why they happen.
+    if(response.body.contains("An error occurred while decrypting the submissions") || response.body.contains("Incorrect password"))
       Left(FormstackDecryptionError(s"${response.body} | form id: ${formId}"))
     else
       decode[FormSubmissions](response.body)

--- a/formstack-baton-requests/src/main/scala/com/gu/identity/formstackbatonrequests/services/FormstackService.scala
+++ b/formstack-baton-requests/src/main/scala/com/gu/identity/formstackbatonrequests/services/FormstackService.scala
@@ -16,7 +16,9 @@ trait FormstackRequestService {
   def deleteUserData(submissionIdEmails: List[SubmissionIdEmail], config: PerformLambdaConfig): Either[Throwable, List[SubmissionDeletionReponse]]
 }
 
-case class FormstackDecryptionError(message: String) extends Throwable
+sealed trait FormstackSkippableError extends Throwable
+case class FormstackDecryptionError(message: String) extends FormstackSkippableError
+case class FormstackAuthError(message: String) extends FormstackSkippableError
 
 object FormstackService extends FormstackRequestService with LazyLogging {
 
@@ -70,10 +72,14 @@ object FormstackService extends FormstackRequestService with LazyLogging {
     /* There are a couple of forms that the Formstack API can't seem to decrypt. There seems to be no way around this
      *  so we capture this specific error and skip these forms. */
     // We also skip responses from Formstack that contain "Incorrect password". These are undocumented, and we do not know why they happen.
-    if(response.body.contains("An error occurred while decrypting the submissions") || response.body.contains("Incorrect password"))
-      Left(FormstackDecryptionError(s"${response.body} | form id: ${formId}"))
-    else
-      decode[FormSubmissions](response.body)
+
+    response.body match {
+      case message if message.contains("An error occurred while decrypting the submissions") =>
+        Left(FormstackDecryptionError(s"${response.body} | form id: ${formId}"))
+      case message if message.contains("Incorrect password") =>
+        Left(FormstackAuthError(s"${response.body} | form id: ${formId}"))
+      case _ => decode[FormSubmissions](response.body)
+    }
   }
 
   private def getSubmissions(

--- a/formstack-baton-requests/src/test/scala/com/gu/identity/formstackbatonrequests/services/DynamoUpdateServiceSpec.scala
+++ b/formstack-baton-requests/src/test/scala/com/gu/identity/formstackbatonrequests/services/DynamoUpdateServiceSpec.scala
@@ -2,7 +2,7 @@ package com.gu.identity.formstackbatonrequests.services
 
 import com.amazonaws.services.lambda.runtime.Context
 import com.gu.identity.formstackbatonrequests.aws.{DynamoClientStub, SubmissionTableUpdateDate}
-import com.gu.identity.formstackbatonrequests.services.FormstackServiceStub.{accountFormsForGivenPageSuccess, deleteDataSuccess, skippableFormstackErrorLeft, submissionDataSuccess}
+import com.gu.identity.formstackbatonrequests.services.FormstackServiceStub.{accountFormsForGivenPageSuccess, deleteDataSuccess, submissionDataSuccess}
 import com.gu.identity.formstackbatonrequests.{FormstackAccountToken, PerformLambdaConfig}
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{EitherValues, FreeSpec, Matchers}

--- a/formstack-baton-requests/src/test/scala/com/gu/identity/formstackbatonrequests/services/DynamoUpdateServiceSpec.scala
+++ b/formstack-baton-requests/src/test/scala/com/gu/identity/formstackbatonrequests/services/DynamoUpdateServiceSpec.scala
@@ -2,6 +2,7 @@ package com.gu.identity.formstackbatonrequests.services
 
 import com.amazonaws.services.lambda.runtime.Context
 import com.gu.identity.formstackbatonrequests.aws.{DynamoClientStub, SubmissionTableUpdateDate}
+import com.gu.identity.formstackbatonrequests.services.FormstackServiceStub.{accountFormsForGivenPageSuccess, deleteDataSuccess, skippableFormstackErrorLeft, submissionDataSuccess}
 import com.gu.identity.formstackbatonrequests.{FormstackAccountToken, PerformLambdaConfig}
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{EitherValues, FreeSpec, Matchers}
@@ -139,6 +140,50 @@ class DynamoUpdateServiceSpec
       )
 
       statusUpdate.left.value shouldBe FormstackServiceStub.genericFormstackError
+    }
+
+    "does not fail when encountering a skippable error in formSubmissionsForGivenPageResponse" in {
+      val skippableFormstackError = FormstackAuthError("Error")
+      val skippableFormstackErrorLeft = Left(skippableFormstackError)
+
+      val withSkippableErrorsFormstackSubmission = new FormstackServiceStub(
+        accountFormsForGivenPageResponse = accountFormsForGivenPageSuccess,
+        formSubmissionsForGivenPageResponse = skippableFormstackErrorLeft,
+        submissionDataResponse = submissionDataSuccess,
+        deleteDataResponse = deleteDataSuccess
+      )
+
+      val dynamoUpdateService: DynamoUpdateService = DynamoUpdateService(
+        formstackClient = withSkippableErrorsFormstackSubmission,
+        dynamoClient = DynamoClientStub.withSuccessResponse,
+        config = mockConfig
+      )
+
+      val mockContext = stub[Context]
+
+      (mockContext.getRemainingTimeInMillis _)
+        .when()
+        .anyNumberOfTimes()
+        .returns(millisLessThan30s)
+
+      val statusUpdate = dynamoUpdateService.updateSubmissionsTable(
+        formsPage = dummyFormsPage,
+        lastUpdate = dummySubmissionsTableUpdateDate,
+        count = dummyCount,
+        token = dummyToken,
+        context = mockContext
+      )
+
+      val expectedUpdateStatus = UpdateStatus(
+        completed = false,
+        formsPage = Some(dummyFormsPage + 1),
+        count = Some(FormstackService.formResultsPerPage),
+        token = dummyToken
+      )
+
+      skippableFormstackError shouldBe a[FormstackSkippableError]
+
+      statusUpdate.right.value shouldBe expectedUpdateStatus
     }
 
     "receives dynamodb errors when calling updateSubmissionsTable" in {


### PR DESCRIPTION
## What does this change?
Some forms return the following 401 response when querying for submissions with the correct credentials.

The query looks like this: `https://www.formstack.com/api/v2/form/$formId/submission.json` and the following is returned from Formstack:

```
{
  "status": "error", 
  "error": "Incorrect password"
}
```

This is undocumented in the Formstack API ( https://developers.formstack.com/reference/form-id-submission-get ) and there is no clear reason as to why this is happening; so we skip this response in a similar way to how we were already skipping responses with a decryption error.