### PR TITLE
Change holidays to guardian traveller

### DIFF
--- a/formstack-consents/README.md
+++ b/formstack-consents/README.md
@@ -4,9 +4,9 @@ Upon a submission to one of the [Formstack](https://guardiannewsandmedia.formsta
 
 When the user clicks the link in the email, an identity account will be created for them and they will be signed up to the newsletter.
 
-Example Formstack newsletter signup forms used for [Professional Networks]:(https://www.theguardian.com/guardian-professional)
-- [Teacher Newsletter](https://www.theguardian.com/teacher-network/2018/mar/21/guardian-teacher-network-newsletter-sign-up)
-- [Society Newsletter](https://www.theguardian.com/society/2018/jun/20/society-weekly-email-newsletter-sign-up)
+28/9/2022 - Formstack forms are not widely used for editorial newsletters as there is a features for dedicated sign-up pages (eg https://www.theguardian.com/lifeandstyle/2015/oct/19/observer-food-monthly-newsletter) and in-article sign up forms in DCR.
+
+A Formstack newsletter signup form is used for Guardian Traveller on the holidays site (https://holidays.theguardian.com/newsletter/) (run by a third party.)
 
 **Notes:**
 

--- a/formstack-consents/src/main/scala/com/gu/identity/formstackconsents/IdentityClient.scala
+++ b/formstack-consents/src/main/scala/com/gu/identity/formstackconsents/IdentityClient.scala
@@ -13,7 +13,7 @@ import scala.util.Try
 
 class IdentityClient(config: Config) extends StrictLogging {
 
-  val newsletters: List[Newsletter] = List(Holidays, Students, Universities, Teachers, Masterclasses, SocietyWeekly, EdinburghFestivalDataCollection, EventMarketingConsentCollection)
+  val newsletters: List[Newsletter] = List(Traveller, Students, Universities, Teachers, Masterclasses, SocietyWeekly, EdinburghFestivalDataCollection, EventMarketingConsentCollection)
 
   val optInForms: List[MarketingConsent] = List(EventMarketingConsentCollection)
 
@@ -101,7 +101,7 @@ object IdentityClient {
     // and sometimes the listType is 'set-consents'. See example body of POST request to IDAPI below.
     //  {
     //    "email" : "example.test@exampledomain.co.uk",
-    //    "set-consents" : "holidays"
+    //    "set-consents" : "supporter"
     //  }
 
     implicit val identityRequestEncoder = IdentityClient.identityRequestEncoder(newsletter)

--- a/formstack-consents/src/main/scala/com/gu/identity/formstackconsents/Newsletter.scala
+++ b/formstack-consents/src/main/scala/com/gu/identity/formstackconsents/Newsletter.scala
@@ -6,10 +6,10 @@ sealed trait Newsletter {
   val consent: String
 }
 
-case object Holidays extends Newsletter {
+case object Traveller extends Newsletter {
   val formId = "1945214"
-  val listType = "set-consents"
-  val consent = "holidays"
+  val listType = "set-lists"
+  val consent = "guardian-traveller"
 }
 
 case object Students extends Newsletter {

--- a/formstack-consents/src/test/scala/IdentityClientTest.scala
+++ b/formstack-consents/src/test/scala/IdentityClientTest.scala
@@ -18,13 +18,13 @@ class IdentityClientTest extends WordSpec with Matchers with MockitoSugar {
   val faultyFormstackSubmission1 = FormstackSubmission("3082194", "test@exampledomain.com", "secretkey", Some(true)) // no opt in required
   val faultyFormstackSubmission2 = FormstackSubmission("3534972", "test@exampledomain.com", "secretkey", None) // missing required opt in
 
-  val holidayRequestBody = "{\"email\":\"test@exampledomain.com\",\"set-consents\":[\"holidays\"]}"
+  val supporterRequestBody = "{\"email\":\"test@exampledomain.com\",\"set-consents\":[\"supporter\"]}"
 
   val studentsRequestBody = "{\"email\":\"test@exampledomain.com\",\"set-lists\":[\"guardian-students\"]}"
 
   "The IdentityClient" should {
     "Correctly encode an Identity Request when the newsletter list-type is set-consents" in {
-      IdentityClient.createRequestBody(email, Holidays).shouldEqual(holidayRequestBody)
+      IdentityClient.createRequestBody(email, EventMarketingConsentCollection).shouldEqual(supporterRequestBody)
     }
 
     "Correctly encode an Identity Request when the newsletter list-type is set-lists" in {


### PR DESCRIPTION
## What does this change?

 - Changes the hook for formstack form #1945214 to trigger a subscription for "Guardian Traveller" (editorial newsletter with identityName "guardian-traveller") instead of the consent-based email "Guardian Holidays", which traveller is replacing.
 - Updates the test for 'set-consent' request to use a different Newsletter (was using `Holidays`).
 - Updates the readme about the usage of this feature.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

After this PR is merged, the form on https://holidays.theguardian.com/newsletter/ should trigger subscriptions to Guardian Traveller - I think this is the only place the formstack-consents feature is used for this form id.

## Have we considered potential risks?
As with  [this pr in identity](https://github.com/guardian/identity/pull/2148), the timeing of the merge needs to be after "holidays" is replaced by "guardian traveller"

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->



