### PR TITLE
Remove all PROD references from formstack-baton-requests CODE 

### DIFF
--- a/formstack-baton-requests/cloud-formation.yaml
+++ b/formstack-baton-requests/cloud-formation.yaml
@@ -154,10 +154,7 @@ Resources:
       Role:
         !GetAtt FormstackBatonSarLambdaRole.Arn
 
-#  There tables are only created in PROD since Formstack doesn't have a CODE environment and we don't want to test in
-#  CODE with real data
   FormstackSubmissionIds:
-    Condition: IsProd
     Type: AWS::DynamoDB::Table
     Properties:
       TableName: !Ref SubmissionsTableName
@@ -176,7 +173,6 @@ Resources:
         WriteCapacityUnits: 20
 
   FormstackSubmissionsLastUpdated:
-    Condition: IsProd
     Type: AWS::DynamoDB::Table
     Properties:
       TableName: !Ref LastUpdatedTableName

--- a/formstack-baton-requests/cloud-formation.yaml
+++ b/formstack-baton-requests/cloud-formation.yaml
@@ -20,22 +20,17 @@ Parameters:
     Type: CommaDelimitedList
   EncryptionPasswordPath:
     Type: String
-    Default: /identity/formstack-baton-requests/encryption-password
   FormstackAccountOneTokenPath:
     Type: String
-    Default: /identity/formstack-baton-requests/formstack-account-one-token
   FormstackAccountTwoTokenPath:
     Type: String
-    Default: /identity/formstack-baton-requests/formstack-account-two-token
   BcryptSaltPath:
     Type: String
-    Default: /identity/formstack-baton-requests/bcrypt-salt
   LastUpdatedTableName:
     Type: String
-    Default: formstack-submissions-last-updated
   SubmissionsTableName:
     Type: String
-    Default: formstack-submission-ids
+
   BatonAccountId:
     Type: String
   AlarmEmailAddress:

--- a/formstack-baton-requests/src/main/scala/com/gu/identity/formstackbatonrequests/services/stub/FormstackServiceStub.scala
+++ b/formstack-baton-requests/src/main/scala/com/gu/identity/formstackbatonrequests/services/stub/FormstackServiceStub.scala
@@ -1,8 +1,9 @@
-package com.gu.identity.formstackbatonrequests.services
+package com.gu.identity.formstackbatonrequests.services.stub
 
 import com.gu.identity.formstackbatonrequests.aws.SubmissionTableUpdateDate
 import com.gu.identity.formstackbatonrequests.circeCodecs.{Form, FormSubmission, FormSubmissions, FormsResponse, ResponseValue, SubmissionDeletionReponse}
 import com.gu.identity.formstackbatonrequests.sar.{FormstackLabelValue, FormstackSubmissionQuestionAnswer, SubmissionIdEmail}
+import com.gu.identity.formstackbatonrequests.services.FormstackRequestService
 import com.gu.identity.formstackbatonrequests.{FormstackAccountToken, PerformLambdaConfig}
 import io.circe.syntax._
 

--- a/formstack-baton-requests/src/test/scala/com/gu/identity/formstackbatonrequests/rer/FormstackPerformRerHandlerSpec.scala
+++ b/formstack-baton-requests/src/test/scala/com/gu/identity/formstackbatonrequests/rer/FormstackPerformRerHandlerSpec.scala
@@ -3,7 +3,7 @@ package com.gu.identity.formstackbatonrequests.rer
 import com.gu.identity.formstackbatonrequests.BatonModels.{Completed, Failed, RerPerformRequest, RerPerformResponse}
 import com.gu.identity.formstackbatonrequests._
 import com.gu.identity.formstackbatonrequests.aws.{DynamoClientStub, S3ClientStub}
-import com.gu.identity.formstackbatonrequests.services.FormstackServiceStub
+import com.gu.identity.formstackbatonrequests.services.stub.FormstackServiceStub
 import org.scalatest.{FreeSpec, Matchers}
 
 class FormstackPerformRerHandlerSpec extends FreeSpec with Matchers {

--- a/formstack-baton-requests/src/test/scala/com/gu/identity/formstackbatonrequests/sar/FormstackPerformSarHandlerSpec.scala
+++ b/formstack-baton-requests/src/test/scala/com/gu/identity/formstackbatonrequests/sar/FormstackPerformSarHandlerSpec.scala
@@ -3,7 +3,7 @@ package com.gu.identity.formstackbatonrequests.sar
 import com.gu.identity.formstackbatonrequests.BatonModels.{Completed, Failed, SarPerformRequest, SarPerformResponse}
 import com.gu.identity.formstackbatonrequests._
 import com.gu.identity.formstackbatonrequests.aws.{DynamoClientStub, S3ClientStub}
-import com.gu.identity.formstackbatonrequests.services.FormstackServiceStub
+import com.gu.identity.formstackbatonrequests.services.stub.FormstackServiceStub
 import org.scalatest.{FreeSpec, Matchers}
 
 class FormstackPerformSarHandlerSpec extends FreeSpec with Matchers {

--- a/formstack-baton-requests/src/test/scala/com/gu/identity/formstackbatonrequests/services/DynamoUpdateServiceSpec.scala
+++ b/formstack-baton-requests/src/test/scala/com/gu/identity/formstackbatonrequests/services/DynamoUpdateServiceSpec.scala
@@ -2,7 +2,8 @@ package com.gu.identity.formstackbatonrequests.services
 
 import com.amazonaws.services.lambda.runtime.Context
 import com.gu.identity.formstackbatonrequests.aws.{DynamoClientStub, SubmissionTableUpdateDate}
-import com.gu.identity.formstackbatonrequests.services.FormstackServiceStub.{accountFormsForGivenPageSuccess, deleteDataSuccess, submissionDataSuccess}
+import com.gu.identity.formstackbatonrequests.services.stub.FormstackServiceStub.{accountFormsForGivenPageSuccess, deleteDataSuccess, submissionDataSuccess}
+import com.gu.identity.formstackbatonrequests.services.stub.FormstackServiceStub
 import com.gu.identity.formstackbatonrequests.{FormstackAccountToken, PerformLambdaConfig}
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{EitherValues, FreeSpec, Matchers}


### PR DESCRIPTION
## What does this change?
The `CODE` instance of formstack-baton-requests was configured with all `PROD` credentials with only the last step of the SAR or RER being replaced with a stub that returned a fake result to Baton. 

This meant that every time Baton was executed in `CODE` formstack-baton-requests would fetch the latests submissions from Formstack and update the production dynamodb table. I don't think this broke anything because it was the exact same code as `PROD` but it is unsafe.

**Change made outside this PR:**
_ Edited the cloudformation parameters in `CODE`  to not refer to any production resources:
 - new dynamodb table names and created a different bcrypt salt
 -  created a `no data` parameter to pass in place of the formstack credentials. This is just to keep things from failing in CODE, but in this PR we are replacing the formstack service with a stub as we still don't have a safe formstack account to use for testing

These changes in the cfn parameters mean that not only will the step function not attempt to access the production resources, but it will not even have the permissions to do so