### PR TITLE
Pv/remove formstack baton remove account two

### DIFF
--- a/formstack-baton-requests/README.md
+++ b/formstack-baton-requests/README.md
@@ -3,23 +3,21 @@
 Formstack Baton Requests consists of 2 step functions and a number of lambdas, which work together to make Subject Access and Right to Erasure Requests to Formstack.
 
 ## Step functions
-As it can take some time to update DynamoDb with Formstack submissions, we use step functions to overcome the 15 minute time limits of lambdas. 
+As it can take some time to update DynamoDb with Formstack submissions, we use step functions to overcome the 15 minute time limit of lambdas. 
 
 ### FormstackSar
 The `FormstackSar` step function is triggered by the `FormstackSarHandler` with an `UpdateDynamoRequest` and has the followings stages:
-1. Branches into 2 parallel paths, one for Formstack account 1 and one for Formstack account 2. Steps 2, 3 and 4 are then performed for both accounts.
-2. Adds an `accountNumber` parameter to each `UpdateDynamoRequest`
-3. Triggers the `UpdateDynamoHandler` (see more information on this lambda below).
-4. Performs a check to see if the status in the `UpdateDynamoResponse` is `Completed`, if it's not, the `UpdateDynamoHandler` is triggered again to continue the update. If a `Completed` status is found, the update branch is completed for that account's token.
-5. Once updates are completed for both tokens, a the `FormstackPerformSarHandler` is triggered (see more information on this lambda below). Steps 2, 3 and 4 are then performed for both accounts.
+1. Adds an `accountNumber` parameter to each `UpdateDynamoRequest` (This is a leftover from when there used to be 2 formstack accounts)
+2. Triggers the `UpdateDynamoHandler` (see more information on this lambda below).
+3. Performs a check to see if the status in the `UpdateDynamoResponse` is `Completed`, if it's not, the `UpdateDynamoHandler` is triggered again to continue the update. If a `Completed` status is found, the update branch is completed for that account's token.
+4. Once updates are completed for both tokens, a the `FormstackPerformSarHandler` is triggered (see more information on this lambda below). Steps 2, 3 and 4 are then performed for both accounts.
 
 ### FormstackRer
 The `FormstackRer` step function is triggered by the `FormstackRerHandler` with an `UpdateDynamoRequest` and has the followings stages:
-1. Branches into 2 parallel paths, one for Formstack account 1 and one for Formstack account 2.
-2. Adds an `accountNumber` parameter to each `UpdateDynamoRequest`
-3. Triggers the `UpdateDynamoHandler` (see more information on this lambda below).
-4. Performs a check to see if the status in the `UpdateDynamoResponse` is `Completed`, if it's not, the `UpdateDynamoHandler` is triggered again to continue the update. If a `Completed` status is found, the update branch is completed for that account's token.
-5. Once updates are completed for both tokens, a the `FormstackPerformRerHandler` is triggered (see more information on this lambda below).
+1. Adds an `accountNumber` parameter to each `UpdateDynamoRequest` ( this is a leftover from when there used to be 2 formstack accounts)
+2. Triggers the `UpdateDynamoHandler` (see more information on this lambda below).
+3. Performs a check to see if the status in the `UpdateDynamoResponse` is `Completed`, if it's not, the `UpdateDynamoHandler` is triggered again to continue the update. If a `Completed` status is found, the update branch is completed for that account's token.
+4. Once updates are completed for both tokens, a the `FormstackPerformRerHandler` is triggered (see more information on this lambda below).
 
 ## Lambdas
 

--- a/formstack-baton-requests/cloud-formation.yaml
+++ b/formstack-baton-requests/cloud-formation.yaml
@@ -646,79 +646,32 @@ Resources:
         - |-
           {
             "Comment": "A step function for performing Formstack RERs",
-            "StartAt": "UpdateDynamoInParallel",
+            "StartAt": "AddAccountOneParam",
             "States": {
-              "UpdateDynamoInParallel": {
-                "Type": "Parallel",
-                "Next": "PerformRer",
-                "Branches": [
+              "AddAccountOneParam": {
+                "Type": "Pass",
+                "Next": "UpdateDynamoWithAccountOne",
+                "Result": "1",
+                "ResultPath": "$.accountNumber"
+              },
+              "UpdateDynamoWithAccountOne": {
+                "Type": "Task",
+                "Resource": "${updateLambdaArn}",
+                "Next": "CheckAccountOneUpdateCompletion"
+              },
+              "CheckAccountOneUpdateCompletion": {
+                "Type": "Choice",
+                "Choices": [
                   {
-                    "StartAt": "AddAccountOneParam",
-                    "States": {
-                      "AddAccountOneParam": {
-                        "Type": "Pass",
-                        "Next": "UpdateDynamoWithAccountOne",
-                        "Result": "1",
-                        "ResultPath": "$.accountNumber"
-                      },
-                      "UpdateDynamoWithAccountOne": {
-                        "Type": "Task",
-                        "Resource": "${updateLambdaArn}",
-                        "Next": "CheckAccountOneUpdateCompletion"
-                      },
-                      "CheckAccountOneUpdateCompletion": {
-                        "Type": "Choice",
-                        "Choices": [
-                          {
-                            "Variable": "$.status",
-                            "StringEquals": "pending",
-                            "Next": "UpdateDynamoWithAccountOne"
-                          }
-                        ],
-                        "Default": "AccountOneUpdateComplete"
-                      },
-                      "AccountOneUpdateComplete": {
-                        "Type": "Pass",
-                        "End": true
-                      }
-                    }
-                  },
-                  {
-                    "StartAt": "AddAccountTwoParam",
-                    "States": {
-                      "AddAccountTwoParam": {
-                        "Type": "Pass",
-                        "Next": "UpdateDynamoWithAccountTwo",
-                        "Result": "2",
-                        "ResultPath": "$.accountNumber"
-                      },
-                      "UpdateDynamoWithAccountTwo": {
-                        "Type": "Task",
-                        "Resource": "${updateLambdaArn}",
-                        "Next": "CheckAccountTwoUpdateCompletion"
-                      },
-                      "CheckAccountTwoUpdateCompletion": {
-                        "Type": "Choice",
-                        "Choices": [
-                          {
-                            "Variable": "$.status",
-                            "StringEquals": "pending",
-                            "Next": "UpdateDynamoWithAccountTwo"
-                          }
-                        ],
-                        "Default": "AccountTwoUpdateComplete"
-                      },
-                      "AccountTwoUpdateComplete": {
-                        "Type": "Pass",
-                        "End": true
-                      }
-                    }
+                    "Variable": "$.status",
+                    "StringEquals": "pending",
+                    "Next": "UpdateDynamoWithAccountOne"
                   }
-                ]
+                ],
+                "Default": "PerformRer"
               },
               "PerformRer": {
                 "Type": "Task",
-                "InputPath": "$[0]",
                 "Resource": "${rerLambdaArn}",
                 "End": true
               }

--- a/formstack-baton-requests/cloud-formation.yaml
+++ b/formstack-baton-requests/cloud-formation.yaml
@@ -600,79 +600,33 @@ Resources:
         - |-
           {
             "Comment": "A step function for performing Formstack SARs",
-            "StartAt": "UpdateDynamoInParallel",
+            "StartAt": "AddAccountOneParam",
             "States": {
-              "UpdateDynamoInParallel": {
-                "Type": "Parallel",
-                "Next": "PerformSar",
-                "Branches": [
-                  {
-                    "StartAt": "AddAccountOneParam",
-                    "States": {
-                      "AddAccountOneParam": {
-                        "Type": "Pass",
-                        "Next": "UpdateDynamoWithAccountOne",
-                        "Result": "1",
-                        "ResultPath": "$.accountNumber"
-                      },
-                      "UpdateDynamoWithAccountOne": {
-                        "Type": "Task",
-                        "Resource": "${updateLambdaArn}",
-                        "Next": "CheckAccountOneUpdateCompletion"
-                      },
-                      "CheckAccountOneUpdateCompletion": {
-                        "Type": "Choice",
-                        "Choices": [
-                          {
-                            "Variable": "$.status",
-                            "StringEquals": "pending",
-                            "Next": "UpdateDynamoWithAccountOne"
-                          }
-                        ],
-                        "Default": "AccountOneUpdateComplete"
-                      },
-                      "AccountOneUpdateComplete": {
-                        "Type": "Pass",
-                        "End": true
-                      }
-                    }
-                  },
-                  {
-                    "StartAt": "AddAccountTwoParam",
-                    "States": {
-                      "AddAccountTwoParam": {
-                        "Type": "Pass",
-                        "Next": "UpdateDynamoWithAccountTwo",
-                        "Result": "2",
-                        "ResultPath": "$.accountNumber"
-                      },
-                      "UpdateDynamoWithAccountTwo": {
-                        "Type": "Task",
-                        "Resource": "${updateLambdaArn}",
-                        "Next": "CheckAccountTwoUpdateCompletion"
-                      },
-                      "CheckAccountTwoUpdateCompletion": {
-                        "Type": "Choice",
-                        "Choices": [
-                          {
-                            "Variable": "$.status",
-                            "StringEquals": "pending",
-                            "Next": "UpdateDynamoWithAccountTwo"
-                          }
-                        ],
-                        "Default": "AccountTwoUpdateComplete"
-                      },
-                      "AccountTwoUpdateComplete": {
-                        "Type": "Pass",
-                        "End": true
-                      }
-                    }
-                  }
-                ]
-              },
+               "AddAccountOneParam": {
+                 "Type": "Pass",
+                 "Next": "UpdateDynamoWithAccountOne",
+                 "Result": "1",
+                 "ResultPath": "$.accountNumber"
+               },
+               "UpdateDynamoWithAccountOne": {
+                 "Type": "Task",
+                 "Resource": "${updateLambdaArn}",
+                 "Next": "CheckAccountOneUpdateCompletion"
+               },
+               "CheckAccountOneUpdateCompletion": {
+                 "Type": "Choice",
+                 "Choices": [
+                   {
+                     "Variable": "$.status",
+                     "StringEquals": "pending",
+                     "Next": "UpdateDynamoWithAccountOne"
+                   }
+                 ],
+                 "Default": "PerformSar"
+               },
+          
               "PerformSar": {
                 "Type": "Task",
-                "InputPath": "$[0]",
                 "Resource": "${sarLambdaArn}",
                 "End": true
               }

--- a/formstack-baton-requests/src/local/com/gu/identity/formstackbatonrequests/services/FormstackRequestServiceProdLocalRun.scala
+++ b/formstack-baton-requests/src/local/com/gu/identity/formstackbatonrequests/services/FormstackRequestServiceProdLocalRun.scala
@@ -18,7 +18,6 @@ object FormstackRequestServiceProdLocalRun extends App {
       resultsPath = "not used",
       encryptionPassword = encryptionPassword,
       accountOneToken = FormstackAccountToken(1, accountOneToken),
-      accountTwoToken = FormstackAccountToken(2, accountTwoToken),
       bcryptSalt = bcryptSalt,
       submissionTableName = "not used",
       lastUpdatedTableName = "not used")).get

--- a/formstack-baton-requests/src/main/scala/com/gu/identity/formstackbatonrequests/FormstackConfig.scala
+++ b/formstack-baton-requests/src/main/scala/com/gu/identity/formstackbatonrequests/FormstackConfig.scala
@@ -15,7 +15,6 @@ case class PerformLambdaConfig (
   resultsPath: String,
   encryptionPassword: String,
   accountOneToken: FormstackAccountToken,
-  accountTwoToken: FormstackAccountToken,
   bcryptSalt: String,
   submissionTableName: String,
   lastUpdatedTableName: String
@@ -51,7 +50,7 @@ object FormstackConfig {
       bcryptSalt <- secureStringFromStore("BCRYPT_SALT_PATH")
       submissionsTableName <- getEnvironmentVariable("SUBMISSION_TABLE_NAME")
       lastUpdatedTableName <- getEnvironmentVariable("LAST_UPDATED_TABLE_NAME")
-    } yield PerformLambdaConfig(resultsBucket, resultsPath, encryptionPassword, FormstackAccountToken(1, accountOneToken), FormstackAccountToken(2, accountTwoToken), bcryptSalt, submissionsTableName, lastUpdatedTableName))
+    } yield PerformLambdaConfig(resultsBucket, resultsPath, encryptionPassword, FormstackAccountToken(1, accountOneToken), bcryptSalt, submissionsTableName, lastUpdatedTableName))
       .getOrElse {
         throw new RuntimeException(
           s"Unable to retrieve environment variables for Formstack Perform SAR Handler"

--- a/formstack-baton-requests/src/main/scala/com/gu/identity/formstackbatonrequests/FormstackConfig.scala
+++ b/formstack-baton-requests/src/main/scala/com/gu/identity/formstackbatonrequests/FormstackConfig.scala
@@ -39,14 +39,12 @@ object FormstackConfig {
         throw new RuntimeException(
           s"Unable to retrieve environment variables for Formstack Init Handler")
       }
-//todo account two is not in use anymore
   def getPerformHandlerConfig: PerformLambdaConfig =
     (for {
       resultsBucket <- getEnvironmentVariable("RESULTS_BUCKET")
       resultsPath <- getEnvironmentVariable("RESULTS_PATH")
       encryptionPassword <- secureStringFromStore("ENCRYPTION_PASSWORD_PATH")
       accountOneToken <- secureStringFromStore("FORMSTACK_ACCOUNT_ONE_TOKEN_PATH")
-      accountTwoToken <- secureStringFromStore("FORMSTACK_ACCOUNT_TWO_TOKEN_PATH")
       bcryptSalt <- secureStringFromStore("BCRYPT_SALT_PATH")
       submissionsTableName <- getEnvironmentVariable("SUBMISSION_TABLE_NAME")
       lastUpdatedTableName <- getEnvironmentVariable("LAST_UPDATED_TABLE_NAME")

--- a/formstack-baton-requests/src/main/scala/com/gu/identity/formstackbatonrequests/FormstackConfig.scala
+++ b/formstack-baton-requests/src/main/scala/com/gu/identity/formstackbatonrequests/FormstackConfig.scala
@@ -39,7 +39,7 @@ object FormstackConfig {
         throw new RuntimeException(
           s"Unable to retrieve environment variables for Formstack Init Handler")
       }
-
+//todo account two is not in use anymore
   def getPerformHandlerConfig: PerformLambdaConfig =
     (for {
       resultsBucket <- getEnvironmentVariable("RESULTS_BUCKET")

--- a/formstack-baton-requests/src/main/scala/com/gu/identity/formstackbatonrequests/services/FormstackService.scala
+++ b/formstack-baton-requests/src/main/scala/com/gu/identity/formstackbatonrequests/services/FormstackService.scala
@@ -19,9 +19,7 @@ trait FormstackRequestService {
 }
 //this used to group results to multiple formstack calls in found and not found results.
 //for not found results we basically have just the id and for the found results we have whatever the particular api call would return
-case class FormstackResponses[T](found:List[T], notFound: List[SubmissionIdEmail])
-//this just used to group results of fetching submissions by which account they were fetched from. This might not agree with the account number dynamodb might assign to the submission
-case class ValidatedSubmissions(accountOneResponse:FormstackResponses[Submission])
+case class FormstackResponses(found:List[Submission], notFound: List[SubmissionIdEmail])
 
 sealed trait FormstackSkippableError extends Throwable
 case class FormstackDecryptionError(message: String) extends FormstackSkippableError
@@ -109,11 +107,11 @@ import FormstackService._
     }
   }
 
-  private def getSubmissions(
+  protected def getSubmissions(
     requestEmail: String,
     submissionIdEmails: List[SubmissionIdEmail],
     accountToken: FormstackAccountToken,
-    encryptionPassword: String): Either[Throwable, FormstackResponses[Submission]] = {
+    encryptionPassword: String): Either[Throwable, FormstackResponses] = {
 
     val submissionResults: Either[Throwable, List[Either[SubmissionIdEmail, Submission]]] = submissionIdEmails.traverse { submissionIdEmail =>
       val response =
@@ -140,7 +138,7 @@ import FormstackService._
     }
 
     submissionResults.map{ subResults =>
-      FormstackResponses[Submission](
+      FormstackResponses(
         found = subResults.collect{ case Right(submission) => submission},
         notFound = subResults.collect{ case Left(skippedSubmissionIdEmail) => skippedSubmissionIdEmail}
       )
@@ -170,51 +168,24 @@ import FormstackService._
     }
   }
 
-  def getSubQandAForAccount(requestEmail:String, accountSubmissions: List[SubmissionIdEmail], token:FormstackAccountToken, encryptionPassword: String)= {
-      for {
-        submissionsResponse <- getSubmissions(requestEmail, accountSubmissions, token, encryptionPassword)
-        labelsAndValues <- getSubmissionQuestionsAnswers(submissionsResponse.found, token)
-      } yield FormstackResponses[FormstackSubmissionQuestionAnswer](found = labelsAndValues, notFound = submissionsResponse.notFound)
-  }
-
-  /**
-   * This method gets a list of submission ids and the form they are expected to be in and returns a ValidatedSubmissions object
-   * which details which submissions were found on each account.
-   * This is useful to support forms migrating from one formstack account to the other as the account number recorded in dynamo would not be accurate anymore
-   *
-   */
-  def getValidatedSubmissionData(requestEmail:String, submissionIdEmails: List[SubmissionIdEmail], config: PerformLambdaConfig): Either[Throwable, ValidatedSubmissions] = {
-    logger.info(s"retrieving submission data for ${submissionIdEmails.length} submissions to validate")
-    for {
-      accountOneResults <- getSubmissions(requestEmail, submissionIdEmails, config.accountOneToken, config.encryptionPassword)
-    } yield ValidatedSubmissions(accountOneResults)
-  }
-
   override def submissionData(requestEmail: String, submissionIdEmails: List[SubmissionIdEmail], config: PerformLambdaConfig): Either[Throwable, List[FormstackSubmissionQuestionAnswer]] = {
     logger.info(s"retrieving submission data for ${submissionIdEmails.length} submissions")
     for {
-      accountOneResults <- getSubQandAForAccount(requestEmail, submissionIdEmails, config.accountOneToken, config.encryptionPassword)
-    } yield accountOneResults.found
+      submissionsResponse <- getSubmissions(requestEmail, submissionIdEmails,  config.accountOneToken, config.encryptionPassword)
+      labelsAndValues <- getSubmissionQuestionsAnswers(submissionsResponse.found,  config.accountOneToken)
+    } yield labelsAndValues
   }
-
+  //fix account number and remove submissions that don't exist in formstack with the correct email
   def validateAndFixSubmissionIdEmails(requestEmail:String, submissionIdEmails: List[SubmissionIdEmail], config: PerformLambdaConfig): Either[Throwable, List[SubmissionIdEmail]] = {
     val submissionIdEmailsById: Map[String, SubmissionIdEmail] = submissionIdEmails.map(sidEmail => sidEmail.submissionId -> sidEmail).toMap
-
-    def fixedSubmissionsFor(subResponse: FormstackResponses[Submission], originAccount: Int): List[SubmissionIdEmail] = {
-      //for each submission found in this account get the submission and make sure it refers to the correct id
-      subResponse.found.map{ validatedSubmission =>
-        submissionIdEmailsById(validatedSubmission.id).copy(accountNumber = originAccount)
-      }.toList
-    }
-
     for {
-      validatedSubmissions <- getValidatedSubmissionData(requestEmail, submissionIdEmails, config)
-    } yield fixedSubmissionsFor(validatedSubmissions.accountOneResponse, 1)
+      submissionsResponse <-  getSubmissions(requestEmail, submissionIdEmails,  config.accountOneToken, config.encryptionPassword)
+      validatedSubmissionIdEmails <- Right(submissionsResponse.found.map(sub => submissionIdEmailsById(sub.id).copy(accountNumber = 1)))
+    } yield validatedSubmissionIdEmails
   }
 
   override def deleteUserData(requestEmail: String, submissionIdEmails: List[SubmissionIdEmail], config: PerformLambdaConfig): Either[Throwable, List[SubmissionDeletionReponse]] = {
     for {
-      //We "fix" the submissions that referer to the wrong formstack account in dynamo
       fixedSubmissionIdEmails <- validateAndFixSubmissionIdEmails(requestEmail, submissionIdEmails, config)
       deleteResponse <- deleteValidatedSubmissions(fixedSubmissionIdEmails, config)
     } yield deleteResponse

--- a/formstack-baton-requests/src/test/scala/com/gu/identity/formstackbatonrequests/rer/FormstackPerformRerHandlerSpec.scala
+++ b/formstack-baton-requests/src/test/scala/com/gu/identity/formstackbatonrequests/rer/FormstackPerformRerHandlerSpec.scala
@@ -13,7 +13,6 @@ class FormstackPerformRerHandlerSpec extends FreeSpec with Matchers {
       "resultsPath",
       "encryptionPassword",
       FormstackAccountToken(1, "accountOneToken"),
-      FormstackAccountToken(2, "accountTwoToken"),
       "bcryptSalt",
       "submissions-table-name",
       "last-updated-table-name"

--- a/formstack-baton-requests/src/test/scala/com/gu/identity/formstackbatonrequests/sar/FormstackPerformSarHandlerSpec.scala
+++ b/formstack-baton-requests/src/test/scala/com/gu/identity/formstackbatonrequests/sar/FormstackPerformSarHandlerSpec.scala
@@ -13,7 +13,6 @@ class FormstackPerformSarHandlerSpec extends FreeSpec with Matchers {
       "resultsPath",
       "encryptionPassword",
       FormstackAccountToken(1, "accountOneToken"),
-      FormstackAccountToken(2, "accountTwoToken"),
       "bcryptSalt",
       "submissions-table-name",
       "last-updated-table-name"

--- a/formstack-baton-requests/src/test/scala/com/gu/identity/formstackbatonrequests/services/DynamoUpdateServiceSpec.scala
+++ b/formstack-baton-requests/src/test/scala/com/gu/identity/formstackbatonrequests/services/DynamoUpdateServiceSpec.scala
@@ -20,7 +20,6 @@ class DynamoUpdateServiceSpec
       "resultsPath",
       "encryptionPassword",
       FormstackAccountToken(1, "accountOneToken"),
-      FormstackAccountToken(2, "accountTwoToken"),
       "bcryptSalt",
       "submissions-table-name",
       "last-updated-table-name"

--- a/formstack-baton-requests/src/test/scala/com/gu/identity/formstackbatonrequests/services/FormstackServiceSpec.scala
+++ b/formstack-baton-requests/src/test/scala/com/gu/identity/formstackbatonrequests/services/FormstackServiceSpec.scala
@@ -15,7 +15,6 @@ class FormstackServiceSpec extends FreeSpec with Matchers with MockFactory {
     resultsPath = "not used",
     encryptionPassword = "encryptionPassword",
     accountOneToken = FormstackAccountToken(1, "accountOneToken"),
-    accountTwoToken = FormstackAccountToken(2, "accountTwoToken"),
     bcryptSalt = "bcryptSalt",
     submissionTableName = "not used",
     lastUpdatedTableName = "not used")
@@ -175,40 +174,38 @@ class FormstackServiceSpec extends FreeSpec with Matchers with MockFactory {
       formstackService.submissionData(testEmail, List(submissionIdEmail111, submissionIdEmail222), config) shouldBe Right(List(parsedSuccessResponse111, parsedSuccessResponse2222))
     }
 
-    "return submissions data from account 2" in {
-      val http = stub[BaseHttp]
-      (http.apply _).when("https://www.formstack.com/api/v2/submission/111.json").returns(successRequest(successResponse111, config.accountTwoToken))
-      (http.apply _).when("https://www.formstack.com/api/v2/submission/222.json").returns(successRequest(successResponse222, config.accountTwoToken))
+//    "return submissions data from account 2" in {
+//      val http = stub[BaseHttp]
+//      (http.apply _).when("https://www.formstack.com/api/v2/submission/111.json").returns(successRequest(successResponse111, config.accountTwoToken))
+//
+//      (http.apply _).when("https://www.formstack.com/api/v2/field/field1").returns(successRequest(successFieldBody1, config.accountTwoToken))
+//      (http.apply _).when("https://www.formstack.com/api/v2/field/field2").returns(successRequest(successFieldBody2, config.accountTwoToken))
+//
+//      val formstackService = new FormstackService(http)
+//      val account2SubmissionIds = List(submissionIdEmail111, submissionIdEmail222).map(_.copy(accountNumber = 2))
+//      formstackService.submissionData(testEmail, submissionIdEmails = account2SubmissionIds, config) shouldBe Right(List(parsedSuccessResponse111, parsedSuccessResponse2222))
+//    }
 
-      (http.apply _).when("https://www.formstack.com/api/v2/field/field1").returns(successRequest(successFieldBody1, config.accountTwoToken))
-      (http.apply _).when("https://www.formstack.com/api/v2/field/field2").returns(successRequest(successFieldBody2, config.accountTwoToken))
-
-      val formstackService = new FormstackService(http)
-      val account2SubmissionIds = List(submissionIdEmail111, submissionIdEmail222).map(_.copy(accountNumber = 2))
-      formstackService.submissionData(testEmail, submissionIdEmails = account2SubmissionIds, config) shouldBe Right(List(parsedSuccessResponse111, parsedSuccessResponse2222))
-    }
-
-    "return submissions data from account 1 and account 2" in {
-      val http = stub[BaseHttp]
-      (http.apply _).when("https://www.formstack.com/api/v2/submission/111.json").returns(successRequest(successResponse111, config.accountOneToken))
-      (http.apply _).when("https://www.formstack.com/api/v2/submission/222.json").returns(successRequest(successResponse222, config.accountTwoToken))
-
-      (http.apply _).when("https://www.formstack.com/api/v2/field/field1").returns(successRequest(successFieldBody1, config.accountOneToken))
-      (http.apply _).when("https://www.formstack.com/api/v2/field/field2").returns(successRequest(successFieldBody2, config.accountTwoToken))
-
-      val formstackService = new FormstackService(http)
-      val mixedSubmissionIds = List(submissionIdEmail111, submissionIdEmail222.copy(accountNumber = 2))
-
-      formstackService.submissionData(testEmail, submissionIdEmails = mixedSubmissionIds, config) shouldBe Right(List(parsedSuccessResponse111, parsedSuccessResponse2222))
-    }
+//    "return submissions data from account 1 and account 2" in {
+//      val http = stub[BaseHttp]
+//      (http.apply _).when("https://www.formstack.com/api/v2/submission/111.json").returns(successRequest(successResponse111, config.accountOneToken))
+//     // (http.apply _).when("https://www.formstack.com/api/v2/submission/222.json").returns(successRequest(successResponse222, config.accountTwoToken))
+//
+//      (http.apply _).when("https://www.formstack.com/api/v2/field/field1").returns(successRequest(successFieldBody1, config.accountOneToken))
+//  //    (http.apply _).when("https://www.formstack.com/api/v2/field/field2").returns(successRequest(successFieldBody2, config.accountTwoToken))
+//
+//      val formstackService = new FormstackService(http)
+//      val mixedSubmissionIds = List(submissionIdEmail111, submissionIdEmail222.copy(accountNumber = 2))
+//
+//      formstackService.submissionData(testEmail, submissionIdEmails = mixedSubmissionIds, config) shouldBe Right(List(parsedSuccessResponse111, parsedSuccessResponse2222))
+//    }
 
     "return error if a non skippable error occurs " in {
       val http = stub[BaseHttp]
       (http.apply _).when("https://www.formstack.com/api/v2/submission/111.json").returns(successRequest(successResponse111, config.accountOneToken))
-      (http.apply _).when("https://www.formstack.com/api/v2/submission/222.json").returns(errorReturningRequest(message ="fake error!", status = 500, token =  config.accountTwoToken))
+      (http.apply _).when("https://www.formstack.com/api/v2/submission/222.json").returns(errorReturningRequest(message ="fake error!", status = 500, token =  config.accountOneToken))
 
       (http.apply _).when("https://www.formstack.com/api/v2/field/field1").returns(successRequest(successFieldBody1, config.accountOneToken))
-      (http.apply _).when("https://www.formstack.com/api/v2/field/field2").returns(successRequest(successFieldBody2, config.accountTwoToken))
 
       val formstackService = new FormstackService(http)
       val mixedSubmissionIds = List(submissionIdEmail111, submissionIdEmail222.copy(accountNumber = 2))
@@ -235,10 +232,10 @@ class FormstackServiceSpec extends FreeSpec with Matchers with MockFactory {
 
             (http.apply _).when("https://www.formstack.com/api/v2/submission/111.json").returns(successRequest(successResponse111, config.accountOneToken))
 
-            val submissionNotFoundInAccountTwo = NotFoundRequest(config.accountTwoToken)
+       //     val submissionNotFoundInAccountTwo = NotFoundRequest(config.accountTwoToken)
             val submissionFoundInAccountOne = successRequest(successResponse222, config.accountOneToken)
             //we assume the first call is in token 2 so we return the mocked response that would throw a null pointer exception if the token one is passed because of how the stub is set up
-            (http.apply _).when("https://www.formstack.com/api/v2/submission/222.json").returns(submissionNotFoundInAccountTwo).noMoreThanOnce()
+       //     (http.apply _).when("https://www.formstack.com/api/v2/submission/222.json").returns(submissionNotFoundInAccountTwo).noMoreThanOnce()
             (http.apply _).when("https://www.formstack.com/api/v2/submission/222.json").returns(submissionFoundInAccountOne).noMoreThanOnce()
 
             (http.apply _).when("https://www.formstack.com/api/v2/field/field1").returns(successRequest(successFieldBody1, config.accountOneToken))
@@ -252,8 +249,8 @@ class FormstackServiceSpec extends FreeSpec with Matchers with MockFactory {
 
       //just to verify the two calls that are made to the same endpoint are done in the correct sequence of first attempting account two and then account one
       inSequence {
-        (submissionNotFoundInAccountTwo.header _).verify("Authorization", config.accountTwoToken.secret)
-        (submissionNotFoundInAccountTwo.asString _).verify()
+     //   (submissionNotFoundInAccountTwo.header _).verify("Authorization", config.accountTwoToken.secret)
+    //    (submissionNotFoundInAccountTwo.asString _).verify()
         (submissionFoundInAccountOne.header _).verify("Authorization", config.accountOneToken.secret)
         (submissionFoundInAccountOne.asString _).verify()
       }
@@ -264,10 +261,10 @@ class FormstackServiceSpec extends FreeSpec with Matchers with MockFactory {
       //      //account one has both submissions
       (http.apply _).when("https://www.formstack.com/api/v2/submission/111.json").returns(successRequest(successResponse111, config.accountOneToken))
 
-      val submissionNotFoundInAccountTwo = NotFoundRequest(config.accountTwoToken)
+ //     val submissionNotFoundInAccountTwo = NotFoundRequest(config.accountTwoToken)
       val submissionNotFoundInAccountOne = NotFoundRequest(config.accountOneToken)
       //we assume the first call is in token 2 so we return the mocked response that would throw a null pointer exception if the token one is passed because of how the stub is set up
-      (http.apply _).when("https://www.formstack.com/api/v2/submission/222.json").returns(submissionNotFoundInAccountTwo).noMoreThanOnce()
+    //  (http.apply _).when("https://www.formstack.com/api/v2/submission/222.json").returns(submissionNotFoundInAccountTwo).noMoreThanOnce()
       (http.apply _).when("https://www.formstack.com/api/v2/submission/222.json").returns(submissionNotFoundInAccountOne).noMoreThanOnce()
 
       (http.apply _).when("https://www.formstack.com/api/v2/field/field1").returns(successRequest(successFieldBody1, config.accountOneToken))
@@ -280,8 +277,8 @@ class FormstackServiceSpec extends FreeSpec with Matchers with MockFactory {
 
       //just to verify the two calls that are made to the same endpoint are done in the correct sequence of first attempting account two and then account one
       inSequence {
-        (submissionNotFoundInAccountTwo.header _).verify("Authorization", config.accountTwoToken.secret)
-        (submissionNotFoundInAccountTwo.asString _).verify()
+   //     (submissionNotFoundInAccountTwo.header _).verify("Authorization", config.accountTwoToken.secret)
+    //    (submissionNotFoundInAccountTwo.asString _).verify()
         (submissionNotFoundInAccountOne.header _).verify("Authorization", config.accountOneToken.secret)
         (submissionNotFoundInAccountOne.asString _).verify()
       }
@@ -289,10 +286,10 @@ class FormstackServiceSpec extends FreeSpec with Matchers with MockFactory {
 
     "Skip submissions not found in account 2 but only found in account 1 but with the wrong email " in {
       val http = stub[BaseHttp]
-      val submissionNotFoundInAccountTwo = NotFoundRequest(config.accountTwoToken)
+  //    val submissionNotFoundInAccountTwo = NotFoundRequest(config.accountTwoToken)
       val submissionFoundInAccountOne = successRequest(successResponse222, config.accountOneToken)
       //we assume the first call is in token 2 so we return the mocked response that would throw a null pointer exception if the token one is passed because of how the stub is set up
-      (http.apply _).when("https://www.formstack.com/api/v2/submission/222.json").returns(submissionNotFoundInAccountTwo).noMoreThanOnce()
+    //  (http.apply _).when("https://www.formstack.com/api/v2/submission/222.json").returns(submissionNotFoundInAccountTwo).noMoreThanOnce()
       (http.apply _).when("https://www.formstack.com/api/v2/submission/222.json").returns(submissionFoundInAccountOne).noMoreThanOnce()
 
       (http.apply _).when("https://www.formstack.com/api/v2/field/field1").returns(successRequest(successFieldBody1, config.accountOneToken))
@@ -304,8 +301,8 @@ class FormstackServiceSpec extends FreeSpec with Matchers with MockFactory {
       formstackService.submissionData("aDifferentEmailNotInFormastack@email.com", List(submissionIdEmail222InAccountTwo), config) shouldBe Right(List.empty)
          //just to verify the two calls that are made to the same endpoint are done in the correct sequence of first attempting account two and then account one
       inSequence {
-        (submissionNotFoundInAccountTwo.header _).verify("Authorization", config.accountTwoToken.secret)
-        (submissionNotFoundInAccountTwo.asString _).verify()
+  //      (submissionNotFoundInAccountTwo.header _).verify("Authorization", config.accountTwoToken.secret)
+   //     (submissionNotFoundInAccountTwo.asString _).verify()
         (submissionFoundInAccountOne.header _).verify("Authorization", config.accountOneToken.secret)
         (submissionFoundInAccountOne.asString _).verify()
       }
@@ -322,50 +319,29 @@ class FormstackServiceSpec extends FreeSpec with Matchers with MockFactory {
       val formstackService = new FormstackService(http)
       val expected = ValidatedSubmissions(
         accountOneResponse = FormstackResponses(found = List(submission111, submission222), notFound = List.empty),
-        accountTwoResponse = FormstackResponses(found = List.empty, notFound = List.empty),
       )
       formstackService.getValidatedSubmissionData(testEmail,List(submissionIdEmail111, submissionIdEmail222), config) shouldBe Right(expected)
     }
     "return submissions data from account 2" in {
       val http = stub[BaseHttp]
-      (http.apply _).when("https://www.formstack.com/api/v2/submission/111.json").returns(successRequest(successResponse111, config.accountTwoToken))
-      (http.apply _).when("https://www.formstack.com/api/v2/submission/222.json").returns(successRequest(successResponse222, config.accountTwoToken))
+//      (http.apply _).when("https://www.formstack.com/api/v2/submission/111.json").returns(successRequest(successResponse111, config.accountTwoToken))
+//      (http.apply _).when("https://www.formstack.com/api/v2/submission/222.json").returns(successRequest(successResponse222, config.accountTwoToken))
 
       val formstackService = new FormstackService(http)
       val expected = ValidatedSubmissions(
         accountOneResponse = FormstackResponses(found = List.empty, notFound = List.empty),
-        accountTwoResponse = FormstackResponses(found = List(submission111, submission222), notFound = List.empty),
       )
       val account2SubmissionIdEmails = List(
-        submissionIdEmail111.copy(accountNumber = config.accountTwoToken.account),
-        submissionIdEmail222.copy(accountNumber = config.accountTwoToken.account))
+//        submissionIdEmail111.copy(accountNumber = config.accountTwoToken.account),
+//        submissionIdEmail222.copy(accountNumber = config.accountTwoToken.account)
+                )
       formstackService.getValidatedSubmissionData(testEmail,account2SubmissionIdEmails, config) shouldBe Right(expected)
     }
 
-    "return submissions data from account 1 and 2" in {
+    "should get from account 1 submissions that are stored as account 1 in dynamodb" in {
       val http = stub[BaseHttp]
-      (http.apply _).when("https://www.formstack.com/api/v2/submission/111.json").returns(successRequest(successResponse111, config.accountOneToken))
-      (http.apply _).when("https://www.formstack.com/api/v2/submission/222.json").returns(successRequest(successResponse222, config.accountTwoToken))
-
-      val formstackService = new FormstackService(http)
-      val expected = ValidatedSubmissions(
-        accountOneResponse = FormstackResponses(found =  List(submission111), notFound = List.empty),
-        accountTwoResponse = FormstackResponses(found = List(submission222), notFound = List.empty),
-      )
-      val mixedAccountSubmissionIdEmails = List(
-        submissionIdEmail111.copy(accountNumber = config.accountOneToken.account),
-        submissionIdEmail222.copy(accountNumber = config.accountTwoToken.account))
-      formstackService.getValidatedSubmissionData(testEmail,mixedAccountSubmissionIdEmails, config) shouldBe Right(expected)
-    }
-
-    "if submissions expected to be in account 2 is not there get it from account 1 " in {
-      val http = stub[BaseHttp]
-      val submissionNotFoundInAccountTwo = NotFoundRequest(config.accountTwoToken)
       val submissionFoundInAccountOne = successRequest(successResponse222, config.accountOneToken)
-      //we assume the first call is in token 2 so we return the mocked response that would throw a null pointer exception if the token one is passed because of how the stub is set up
-      (http.apply _).when("https://www.formstack.com/api/v2/submission/222.json").returns(submissionNotFoundInAccountTwo).noMoreThanOnce()
-      (http.apply _).when("https://www.formstack.com/api/v2/submission/222.json").returns(submissionFoundInAccountOne).noMoreThanOnce()
-
+      (http.apply _).when("https://www.formstack.com/api/v2/submission/222.json").returns(submissionFoundInAccountOne)
       (http.apply _).when("https://www.formstack.com/api/v2/submission/111.json").returns(successRequest(successResponse111, config.accountOneToken))
 
 
@@ -376,17 +352,15 @@ class FormstackServiceSpec extends FreeSpec with Matchers with MockFactory {
         submissionIdEmail111,
         subsmissionIdEmail11FromAccount2)
 
-      val expected = ValidatedSubmissions(
-        accountOneResponse =  FormstackResponses(found = List(submission111, submission222), notFound = List.empty),
-        accountTwoResponse = FormstackResponses(found =  List.empty, notFound = List(subsmissionIdEmail11FromAccount2)),
-      )
+      val expected = ValidatedSubmissions(FormstackResponses(found = List(submission111, submission222), notFound = List.empty))
+
 
       formstackService.getValidatedSubmissionData(testEmail,mixedAccountSubmissionIdEmails, config) shouldBe Right(expected)
 
       //just to verify the two calls that are made to the same endpoint are done in the correct sequence of first attempting account two and then account one
       inSequence {
-        (submissionNotFoundInAccountTwo.header _).verify("Authorization", config.accountTwoToken.secret)
-        (submissionNotFoundInAccountTwo.asString _).verify()
+   //     (submissionNotFoundInAccountTwo.header _).verify("Authorization", config.accountTwoToken.secret)
+    //    (submissionNotFoundInAccountTwo.asString _).verify()
         (submissionFoundInAccountOne.header _).verify("Authorization", config.accountOneToken.secret)
         (submissionFoundInAccountOne.asString _).verify()
       }
@@ -395,14 +369,13 @@ class FormstackServiceSpec extends FreeSpec with Matchers with MockFactory {
   "FormstackService.validateAndFixSubmissionIdEmails" - {
     "return the list unchanged if all the submissions are found in the expected account" in {
       val submissionsIds = List(
-        submissionIdEmail111, submissionIdEmail222.copy(accountNumber = 2)
+        submissionIdEmail111, submissionIdEmail222
       )
       val http = stub[BaseHttp]
       val formstackService = new FormstackService(http) {
         override def getValidatedSubmissionData(requestEmail:String , submissionIdEmails: List[SubmissionIdEmail], config: PerformLambdaConfig) = Right(
           ValidatedSubmissions(
-            accountOneResponse =  FormstackResponses(found = List(submission111), notFound = List.empty),
-            accountTwoResponse = FormstackResponses(found =  List(submission222), notFound = List.empty),
+            accountOneResponse =  FormstackResponses(found = List(submission111, submission222), notFound = List.empty),
           ))
       }
 
@@ -417,10 +390,7 @@ class FormstackServiceSpec extends FreeSpec with Matchers with MockFactory {
       val http = stub[BaseHttp]
       val formstackService = new FormstackService(http) {
         override def getValidatedSubmissionData(requestEmail:String, submissionIdEmails: List[SubmissionIdEmail], config: PerformLambdaConfig) = Right(
-          ValidatedSubmissions(
-            accountOneResponse =  FormstackResponses(found = List(submission111, submission222), notFound = List.empty),
-            accountTwoResponse = FormstackResponses(found =  List.empty, notFound = List(submissionIdEmail111)),
-          ))
+          ValidatedSubmissions(FormstackResponses(found = List(submission111, submission222), notFound = List.empty)))
       }
       val SubmissionIdsAllInAccountOne = List(
         submissionIdEmail111,
@@ -439,7 +409,7 @@ class FormstackServiceSpec extends FreeSpec with Matchers with MockFactory {
         override def getValidatedSubmissionData(requestEmail:String, submissionIdEmails: List[SubmissionIdEmail], config: PerformLambdaConfig) = Right(
           ValidatedSubmissions(
             accountOneResponse =  FormstackResponses(found = List.empty, notFound = List(submissionIdEmail222, submissionIdEmail111)),
-            accountTwoResponse = FormstackResponses(found =  List.empty, notFound = List(submissionIdEmail111)),
+//            accountTwoResponse = FormstackResponses(found =  List.empty, notFound = List(submissionIdEmail111)),
           ))
       }
 
@@ -474,7 +444,7 @@ class FormstackServiceSpec extends FreeSpec with Matchers with MockFactory {
       val formstackService = new FormstackService(http)
       val expected = ValidatedSubmissions(
         accountOneResponse = FormstackResponses(found =  List(submission111), notFound = List(submissionIdEmail222)),
-        accountTwoResponse = FormstackResponses(found = List.empty, notFound = List.empty),
+//        accountTwoResponse = FormstackResponses(found = List.empty, notFound = List.empty),
       )
       val subIds = List(
         submissionIdEmail111,

--- a/formstack-baton-requests/src/test/scala/com/gu/identity/formstackbatonrequests/services/FormstackServiceSpec.scala
+++ b/formstack-baton-requests/src/test/scala/com/gu/identity/formstackbatonrequests/services/FormstackServiceSpec.scala
@@ -174,32 +174,6 @@ class FormstackServiceSpec extends FreeSpec with Matchers with MockFactory {
       formstackService.submissionData(testEmail, List(submissionIdEmail111, submissionIdEmail222), config) shouldBe Right(List(parsedSuccessResponse111, parsedSuccessResponse2222))
     }
 
-//    "return submissions data from account 2" in {
-//      val http = stub[BaseHttp]
-//      (http.apply _).when("https://www.formstack.com/api/v2/submission/111.json").returns(successRequest(successResponse111, config.accountTwoToken))
-//
-//      (http.apply _).when("https://www.formstack.com/api/v2/field/field1").returns(successRequest(successFieldBody1, config.accountTwoToken))
-//      (http.apply _).when("https://www.formstack.com/api/v2/field/field2").returns(successRequest(successFieldBody2, config.accountTwoToken))
-//
-//      val formstackService = new FormstackService(http)
-//      val account2SubmissionIds = List(submissionIdEmail111, submissionIdEmail222).map(_.copy(accountNumber = 2))
-//      formstackService.submissionData(testEmail, submissionIdEmails = account2SubmissionIds, config) shouldBe Right(List(parsedSuccessResponse111, parsedSuccessResponse2222))
-//    }
-
-//    "return submissions data from account 1 and account 2" in {
-//      val http = stub[BaseHttp]
-//      (http.apply _).when("https://www.formstack.com/api/v2/submission/111.json").returns(successRequest(successResponse111, config.accountOneToken))
-//     // (http.apply _).when("https://www.formstack.com/api/v2/submission/222.json").returns(successRequest(successResponse222, config.accountTwoToken))
-//
-//      (http.apply _).when("https://www.formstack.com/api/v2/field/field1").returns(successRequest(successFieldBody1, config.accountOneToken))
-//  //    (http.apply _).when("https://www.formstack.com/api/v2/field/field2").returns(successRequest(successFieldBody2, config.accountTwoToken))
-//
-//      val formstackService = new FormstackService(http)
-//      val mixedSubmissionIds = List(submissionIdEmail111, submissionIdEmail222.copy(accountNumber = 2))
-//
-//      formstackService.submissionData(testEmail, submissionIdEmails = mixedSubmissionIds, config) shouldBe Right(List(parsedSuccessResponse111, parsedSuccessResponse2222))
-//    }
-
     "return error if a non skippable error occurs " in {
       val http = stub[BaseHttp]
       (http.apply _).when("https://www.formstack.com/api/v2/submission/111.json").returns(successRequest(successResponse111, config.accountOneToken))
@@ -235,7 +209,6 @@ class FormstackServiceSpec extends FreeSpec with Matchers with MockFactory {
        //     val submissionNotFoundInAccountTwo = NotFoundRequest(config.accountTwoToken)
             val submissionFoundInAccountOne = successRequest(successResponse222, config.accountOneToken)
             //we assume the first call is in token 2 so we return the mocked response that would throw a null pointer exception if the token one is passed because of how the stub is set up
-       //     (http.apply _).when("https://www.formstack.com/api/v2/submission/222.json").returns(submissionNotFoundInAccountTwo).noMoreThanOnce()
             (http.apply _).when("https://www.formstack.com/api/v2/submission/222.json").returns(submissionFoundInAccountOne).noMoreThanOnce()
 
             (http.apply _).when("https://www.formstack.com/api/v2/field/field1").returns(successRequest(successFieldBody1, config.accountOneToken))
@@ -249,48 +222,50 @@ class FormstackServiceSpec extends FreeSpec with Matchers with MockFactory {
 
       //just to verify the two calls that are made to the same endpoint are done in the correct sequence of first attempting account two and then account one
       inSequence {
-     //   (submissionNotFoundInAccountTwo.header _).verify("Authorization", config.accountTwoToken.secret)
-    //    (submissionNotFoundInAccountTwo.asString _).verify()
         (submissionFoundInAccountOne.header _).verify("Authorization", config.accountOneToken.secret)
         (submissionFoundInAccountOne.asString _).verify()
       }
       }
 
-    "skip submissions that are expected in account 2 but they are not found in either account " in {
+    "skip submissions that are expected in account 2 but they are not found in account 1 " in {
       val http = stub[BaseHttp]
       //      //account one has both submissions
       (http.apply _).when("https://www.formstack.com/api/v2/submission/111.json").returns(successRequest(successResponse111, config.accountOneToken))
 
- //     val submissionNotFoundInAccountTwo = NotFoundRequest(config.accountTwoToken)
       val submissionNotFoundInAccountOne = NotFoundRequest(config.accountOneToken)
-      //we assume the first call is in token 2 so we return the mocked response that would throw a null pointer exception if the token one is passed because of how the stub is set up
-    //  (http.apply _).when("https://www.formstack.com/api/v2/submission/222.json").returns(submissionNotFoundInAccountTwo).noMoreThanOnce()
-      (http.apply _).when("https://www.formstack.com/api/v2/submission/222.json").returns(submissionNotFoundInAccountOne).noMoreThanOnce()
+      (http.apply _).when("https://www.formstack.com/api/v2/submission/222.json").returns(submissionNotFoundInAccountOne)
 
       (http.apply _).when("https://www.formstack.com/api/v2/field/field1").returns(successRequest(successFieldBody1, config.accountOneToken))
 
       val formstackService = new FormstackService(http)
       val mixedSubmissionIds = List(submissionIdEmail111, submissionIdEmail222.copy(accountNumber = 2))
 
-      //account 222 is not in the response as it was not found in either account
+      //account 222 is not in the response as it was not found in formstack
       formstackService.submissionData(testEmail, mixedSubmissionIds, config) shouldBe Right(List(parsedSuccessResponse111))
 
       //just to verify the two calls that are made to the same endpoint are done in the correct sequence of first attempting account two and then account one
       inSequence {
-   //     (submissionNotFoundInAccountTwo.header _).verify("Authorization", config.accountTwoToken.secret)
-    //    (submissionNotFoundInAccountTwo.asString _).verify()
         (submissionNotFoundInAccountOne.header _).verify("Authorization", config.accountOneToken.secret)
         (submissionNotFoundInAccountOne.asString _).verify()
       }
     }
+    "Skip submissions that contain no references to the request email " in {
+      val http = stub[BaseHttp]
+      //    val submissionNotFoundInAccountTwo = NotFoundRequest(config.accountTwoToken)
+      val submissionFoundInAccountOne = successRequest(successResponse222, config.accountOneToken)
+      (http.apply _).when("https://www.formstack.com/api/v2/submission/222.json").returns(submissionFoundInAccountOne)
+      (http.apply _).when("https://www.formstack.com/api/v2/field/field1").returns(successRequest(successFieldBody1, config.accountOneToken))
+      (http.apply _).when("https://www.formstack.com/api/v2/field/field2").returns(successRequest(successFieldBody2, config.accountOneToken))
 
-    "Skip submissions not found in account 2 but only found in account 1 but with the wrong email " in {
+      val formstackService = new FormstackService(http)
+      formstackService.submissionData("aDifferentEmailNotInFormastack@email.com", List(submissionIdEmail222), config) shouldBe Right(List.empty)
+    }
+
+    "Skip submissions saved as account 2 but only found in account 1 but with the wrong email " in {
       val http = stub[BaseHttp]
   //    val submissionNotFoundInAccountTwo = NotFoundRequest(config.accountTwoToken)
       val submissionFoundInAccountOne = successRequest(successResponse222, config.accountOneToken)
-      //we assume the first call is in token 2 so we return the mocked response that would throw a null pointer exception if the token one is passed because of how the stub is set up
-    //  (http.apply _).when("https://www.formstack.com/api/v2/submission/222.json").returns(submissionNotFoundInAccountTwo).noMoreThanOnce()
-      (http.apply _).when("https://www.formstack.com/api/v2/submission/222.json").returns(submissionFoundInAccountOne).noMoreThanOnce()
+          (http.apply _).when("https://www.formstack.com/api/v2/submission/222.json").returns(submissionFoundInAccountOne).noMoreThanOnce()
 
       (http.apply _).when("https://www.formstack.com/api/v2/field/field1").returns(successRequest(successFieldBody1, config.accountOneToken))
       (http.apply _).when("https://www.formstack.com/api/v2/field/field2").returns(successRequest(successFieldBody2, config.accountOneToken))
@@ -307,65 +282,10 @@ class FormstackServiceSpec extends FreeSpec with Matchers with MockFactory {
         (submissionFoundInAccountOne.asString _).verify()
       }
     }
+
+
   }
 
-  "FormstackService.getValidatedSubmissionData" - {
-
-    "return submissions data from account 1" in {
-      val http = stub[BaseHttp]
-      (http.apply _).when("https://www.formstack.com/api/v2/submission/111.json").returns(successRequest(successResponse111, config.accountOneToken))
-      (http.apply _).when("https://www.formstack.com/api/v2/submission/222.json").returns(successRequest(successResponse222, config.accountOneToken))
-
-      val formstackService = new FormstackService(http)
-      val expected = ValidatedSubmissions(
-        accountOneResponse = FormstackResponses(found = List(submission111, submission222), notFound = List.empty),
-      )
-      formstackService.getValidatedSubmissionData(testEmail,List(submissionIdEmail111, submissionIdEmail222), config) shouldBe Right(expected)
-    }
-    "return submissions data from account 2" in {
-      val http = stub[BaseHttp]
-//      (http.apply _).when("https://www.formstack.com/api/v2/submission/111.json").returns(successRequest(successResponse111, config.accountTwoToken))
-//      (http.apply _).when("https://www.formstack.com/api/v2/submission/222.json").returns(successRequest(successResponse222, config.accountTwoToken))
-
-      val formstackService = new FormstackService(http)
-      val expected = ValidatedSubmissions(
-        accountOneResponse = FormstackResponses(found = List.empty, notFound = List.empty),
-      )
-      val account2SubmissionIdEmails = List(
-//        submissionIdEmail111.copy(accountNumber = config.accountTwoToken.account),
-//        submissionIdEmail222.copy(accountNumber = config.accountTwoToken.account)
-                )
-      formstackService.getValidatedSubmissionData(testEmail,account2SubmissionIdEmails, config) shouldBe Right(expected)
-    }
-
-    "should get from account 1 submissions that are stored as account 1 in dynamodb" in {
-      val http = stub[BaseHttp]
-      val submissionFoundInAccountOne = successRequest(successResponse222, config.accountOneToken)
-      (http.apply _).when("https://www.formstack.com/api/v2/submission/222.json").returns(submissionFoundInAccountOne)
-      (http.apply _).when("https://www.formstack.com/api/v2/submission/111.json").returns(successRequest(successResponse111, config.accountOneToken))
-
-
-      val formstackService = new FormstackService(http)
-
-      val subsmissionIdEmail11FromAccount2 = submissionIdEmail222.copy(accountNumber = 2)
-      val mixedAccountSubmissionIdEmails = List(
-        submissionIdEmail111,
-        subsmissionIdEmail11FromAccount2)
-
-      val expected = ValidatedSubmissions(FormstackResponses(found = List(submission111, submission222), notFound = List.empty))
-
-
-      formstackService.getValidatedSubmissionData(testEmail,mixedAccountSubmissionIdEmails, config) shouldBe Right(expected)
-
-      //just to verify the two calls that are made to the same endpoint are done in the correct sequence of first attempting account two and then account one
-      inSequence {
-   //     (submissionNotFoundInAccountTwo.header _).verify("Authorization", config.accountTwoToken.secret)
-    //    (submissionNotFoundInAccountTwo.asString _).verify()
-        (submissionFoundInAccountOne.header _).verify("Authorization", config.accountOneToken.secret)
-        (submissionFoundInAccountOne.asString _).verify()
-      }
-    }
-  }
   "FormstackService.validateAndFixSubmissionIdEmails" - {
     "return the list unchanged if all the submissions are found in the expected account" in {
       val submissionsIds = List(
@@ -373,10 +293,8 @@ class FormstackServiceSpec extends FreeSpec with Matchers with MockFactory {
       )
       val http = stub[BaseHttp]
       val formstackService = new FormstackService(http) {
-        override def getValidatedSubmissionData(requestEmail:String , submissionIdEmails: List[SubmissionIdEmail], config: PerformLambdaConfig) = Right(
-          ValidatedSubmissions(
-            accountOneResponse =  FormstackResponses(found = List(submission111, submission222), notFound = List.empty),
-          ))
+        override def getSubmissions(requestEmail: String, submissionIdEmails: List[SubmissionIdEmail], accountToken: FormstackAccountToken, encryptionPassword: String): Either[Throwable, FormstackResponses] =
+          Right( FormstackResponses(found = List(submission111, submission222), notFound = List.empty))
       }
 
       formstackService.validateAndFixSubmissionIdEmails(testEmail, submissionsIds, config)  shouldBe Right(submissionsIds)
@@ -389,8 +307,8 @@ class FormstackServiceSpec extends FreeSpec with Matchers with MockFactory {
       )
       val http = stub[BaseHttp]
       val formstackService = new FormstackService(http) {
-        override def getValidatedSubmissionData(requestEmail:String, submissionIdEmails: List[SubmissionIdEmail], config: PerformLambdaConfig) = Right(
-          ValidatedSubmissions(FormstackResponses(found = List(submission111, submission222), notFound = List.empty)))
+        override def getSubmissions(requestEmail: String, submissionIdEmails: List[SubmissionIdEmail], accountToken: FormstackAccountToken, encryptionPassword: String) = Right(
+          FormstackResponses(found = List(submission111, submission222), notFound = List.empty))
       }
       val SubmissionIdsAllInAccountOne = List(
         submissionIdEmail111,
@@ -399,18 +317,15 @@ class FormstackServiceSpec extends FreeSpec with Matchers with MockFactory {
       formstackService.validateAndFixSubmissionIdEmails(testEmail, account2Submissions, config)  shouldBe Right(SubmissionIdsAllInAccountOne)
     }
 
-    "remove submissions that are not found in either account" in {
+    "remove submissions that are not found in Formstack" in {
       val account2Submissions = List(
         submissionIdEmail111.copy(accountNumber = 2),
         submissionIdEmail222.copy(accountNumber = 2)
       )
       val http = stub[BaseHttp]
       val formstackService = new FormstackService(http) {
-        override def getValidatedSubmissionData(requestEmail:String, submissionIdEmails: List[SubmissionIdEmail], config: PerformLambdaConfig) = Right(
-          ValidatedSubmissions(
-            accountOneResponse =  FormstackResponses(found = List.empty, notFound = List(submissionIdEmail222, submissionIdEmail111)),
-//            accountTwoResponse = FormstackResponses(found =  List.empty, notFound = List(submissionIdEmail111)),
-          ))
+        override def getSubmissions(requestEmail: String, submissionIdEmails: List[SubmissionIdEmail], accountToken: FormstackAccountToken, encryptionPassword: String) = Right(
+          FormstackResponses(found = List.empty, notFound = List(submissionIdEmail222, submissionIdEmail111)))
       }
 
       formstackService.validateAndFixSubmissionIdEmails(testEmail, account2Submissions, config)  shouldBe Right(List.empty)
@@ -442,14 +357,8 @@ class FormstackServiceSpec extends FreeSpec with Matchers with MockFactory {
       (http.apply _).when("https://www.formstack.com/api/v2/submission/222.json").returns(successRequest(response222WithTheWrongEmail, config.accountOneToken))
 
       val formstackService = new FormstackService(http)
-      val expected = ValidatedSubmissions(
-        accountOneResponse = FormstackResponses(found =  List(submission111), notFound = List(submissionIdEmail222)),
-//        accountTwoResponse = FormstackResponses(found = List.empty, notFound = List.empty),
-      )
-      val subIds = List(
-        submissionIdEmail111,
-        submissionIdEmail222)
-      formstackService.getValidatedSubmissionData(testEmail,subIds, config) shouldBe Right(expected)
+      val subIds = List(submissionIdEmail111, submissionIdEmail222)
+      formstackService.validateAndFixSubmissionIdEmails(testEmail,subIds, config) shouldBe Right(List(submissionIdEmail111))
     }
   }
   "FormstackService.validateEmail" - {


### PR DESCRIPTION
## What does this change?
Formstack forms are being migrated away from account 2.  The current code assumes we have 2 formstack accounts and will cause failures is the credentials for account 2 stop working. 
This PR removes account 2 references and makes the project work with a single account.
There's still more refactoring that could be done to simplify the code now that there's a single account but we will leave that for later, maybe once we get a fully functional `CODE`  environment.

## Step function changes
### FormstackSAR
### before
<img width="429" alt="image" src="https://user-images.githubusercontent.com/15324270/210547302-bd0175a1-3603-4e1e-8e70-cb2dda52c5e2.png">

### after
<img width="272" alt="image" src="https://user-images.githubusercontent.com/15324270/210547386-2d56b194-13ee-42d5-b231-eafa35512c82.png">

### FormstackRER
### before
<img width="431" alt="image" src="https://user-images.githubusercontent.com/15324270/210547567-e89b8337-dcc8-4b19-9be7-837111feb3c7.png">

### after
<img width="272" alt="image" src="https://user-images.githubusercontent.com/15324270/210547487-f7d4be50-7859-4de5-8fbb-342aafec2de3.png">
