### PR TITLE
update formstack ids for Traveller and MasterClass newsletter forms

### DIFF
--- a/formstack-consents/src/main/scala/com/gu/identity/formstackconsents/Newsletter.scala
+++ b/formstack-consents/src/main/scala/com/gu/identity/formstackconsents/Newsletter.scala
@@ -6,6 +6,8 @@ sealed trait Newsletter {
   val consent: String
 }
 
+// used on subsite managed by a third party https://holidays.theguardian.com/newsletter/
+// form url https://guardiannewsandmedia.formstack.com/forms/holidays_newsletter
 case object Traveller extends Newsletter {
   val formId = "5136217"
   val listType = "set-lists"
@@ -30,6 +32,7 @@ case object Teachers extends Newsletter {
   val consent = "teacher-network"
 }
 
+// form url https://guardiannewsandmedia.formstack.com/forms/masterclasses_newsletter
 case object Masterclasses extends Newsletter {
   val formId = "5136221"
   val listType = "set-consents"

--- a/formstack-consents/src/main/scala/com/gu/identity/formstackconsents/Newsletter.scala
+++ b/formstack-consents/src/main/scala/com/gu/identity/formstackconsents/Newsletter.scala
@@ -7,7 +7,7 @@ sealed trait Newsletter {
 }
 
 case object Traveller extends Newsletter {
-  val formId = "1945214"
+  val formId = "5136217"
   val listType = "set-lists"
   val consent = "guardian-traveller"
 }
@@ -31,7 +31,7 @@ case object Teachers extends Newsletter {
 }
 
 case object Masterclasses extends Newsletter {
-  val formId = "1898609"
+  val formId = "5136221"
   val listType = "set-consents"
   val consent = "events"
 }


### PR DESCRIPTION
## What does this change?
Updates formstack ids for Traveller and MasterClass newsletter forms.

The old forms were deleted on 9th January as they weren't categorised as belonging to any team and remained 'unclaimed' after comms went out. 

## How to test

There isn't a way to test this in development, but we can make this change without embedding the form on any pages, then test the sign-up mechanism and only embed the forms if they work.

looking at https://github.com/guardian/identity-processes/blob/main/formstack-consents/src/main/scala/com/gu/identity/formstackconsents/Lambda.scala , it seems a form submission from these forms would provide the required data (`emailAddress` and `formId`)

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?
Submitting the forms (URLs to stand-alone versions below) should in the signup request going to the identity API.
https://guardiannewsandmedia.formstack.com/forms/masterclasses_newsletter
https://guardiannewsandmedia.formstack.com/forms/holidays_newsletter

Once verified, the new forms can be embeded on the pages the old forms were on.

## Have we considered potential risks?

It is known that these new forms need an owner - will be following up with the Product managers to decide if they should both be under 'newsletters' or under 'holidays' and 'masterclasses' (or similar).

