### PR TITLE
add extra logging to track error

### DIFF
--- a/formstack-consents/src/main/scala/com/gu/identity/formstackconsents/IdentityClient.scala
+++ b/formstack-consents/src/main/scala/com/gu/identity/formstackconsents/IdentityClient.scala
@@ -72,9 +72,11 @@ class IdentityClient(config: Config) extends StrictLogging {
     if (checkHasOptedIn(formstackSubmission)) {
       newsletterOpt.flatMap { newsletter => {
         val response = updateConsent(formstackSubmission, newsletter)
+        logger.info(s"sendConsentToIdentity: got response from updateConsent")
         handleResponseFromIdentity(response, formstackSubmission, newsletter)
       }}
     } else {
+      logger.info(s"sendConsentToIdentity: form is not submitted due to missing consent opt in requirements")
       None // form is not submitted due to missing consent opt in requirements
     }
   }

--- a/formstack-consents/src/main/scala/com/gu/identity/formstackconsents/Lambda.scala
+++ b/formstack-consents/src/main/scala/com/gu/identity/formstackconsents/Lambda.scala
@@ -23,7 +23,13 @@ object Lambda extends StrictLogging {
 
   def verifySecretKey(formstackSharedSecret: String, secretKeyFromRequest: String): Option[Boolean] = {
     val isValid = formstackSharedSecret == secretKeyFromRequest
-    if (isValid) { Some(true) } else { None }
+    if (isValid) { 
+      logger.info(s"verifySecretKey: isValid is true")
+      Some(true) 
+    } else { 
+      logger.info(s"verifySecretKey: isValid is false")
+      None 
+    }
   }
 
   def decodeFormstackSubmission(eventBody: String): Option[FormstackSubmission] = {


### PR DESCRIPTION
## What does this change?

Adds extra debug logging to track why a formstack form isn't working - intended to be deployed to code only.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
