### PR TITLE
Configure Scala projects for Scala Steward

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,12 @@
+# Repository-specific configuration
+# See https://github.com/scala-steward-org/scala-steward/blob/main/docs/repo-specific-configuration.md for template
+
+# It is possible to have multiple scala projects in a single repository. In that case the folders containing the projects (build.sbt folders)
+# are specified using the buildRoots property. Note that the paths used there are relative and if the repo directory itself also contains a build.sbt the dot can be used to specify it.
+# Default: ["."]
+buildRoots = [
+  "eventbrite-consents",
+  "formstack-baton-requests",
+  "formstack-consents",
+  "payment-failure"
+]


### PR DESCRIPTION
This repo is already on the [list of public repos accessible to Scala Steward](https://github.com/guardian/scala-steward-public-repos/blob/main/REPOSITORIES.md).  But unfortunately no dependencies are being monitored because this repo actually holds four Scala sub-projects.  This means that for Scala Steward to monitor dependencies in the repo it needs to know the locations of these sub-projects.
