### PR TITLE
update java8-al2 to java11 for Formstack Baton Request

### DIFF
--- a/formstack-baton-requests/cloud-formation.yaml
+++ b/formstack-baton-requests/cloud-formation.yaml
@@ -140,7 +140,7 @@ Resources:
           RESULTS_PATH: !Sub formstack-results/${Stage}
           STATE_MACHINE_ARN: !Ref FormstackSar
       MemorySize: 1024
-      Runtime: java8.al2
+      Runtime: java11
       Timeout: 120
       VpcConfig:
         SecurityGroupIds:
@@ -268,7 +268,7 @@ Resources:
           SUBMISSION_TABLE_NAME: !Ref SubmissionsTableName
           LAST_UPDATED_TABLE_NAME: !Ref LastUpdatedTableName
       MemorySize: 1024
-      Runtime: java8.al2
+      Runtime: java11
       Timeout: 900
       VpcConfig:
         SecurityGroupIds:
@@ -341,7 +341,7 @@ Resources:
           RESULTS_PATH: !Sub formstack-results/${Stage}
           STATE_MACHINE_ARN: !Ref FormstackRer
       MemorySize: 1024
-      Runtime: java8.al2
+      Runtime: java11
       Timeout: 120
       VpcConfig:
         SecurityGroupIds:
@@ -438,7 +438,7 @@ Resources:
           SUBMISSION_TABLE_NAME: !Ref SubmissionsTableName
           LAST_UPDATED_TABLE_NAME: !Ref LastUpdatedTableName
       MemorySize: 1024
-      Runtime: java8.al2
+      Runtime: java11
       Timeout: 900
       VpcConfig:
         SecurityGroupIds:
@@ -536,7 +536,7 @@ Resources:
           SUBMISSION_TABLE_NAME: !Ref SubmissionsTableName
           LAST_UPDATED_TABLE_NAME: !Ref LastUpdatedTableName
       MemorySize: 1024
-      Runtime: java8.al2
+      Runtime: java11
       Timeout: 900
       VpcConfig:
         SecurityGroupIds:

--- a/formstack-baton-requests/project/build.properties
+++ b/formstack-baton-requests/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.5.7
+sbt.version =1.6.2

--- a/formstack-baton-requests/project/plugins.sbt
+++ b/formstack-baton-requests/project/plugins.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.0.0")
+addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.18")
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")


### PR DESCRIPTION
## What does this change?

This changes the Runtime Environment from Java 8 to 11 for Formstack Baton Request.

## How to test

Deploy to CODE and test against Formstack
Check that the build works in Teamcity with Java 11 - Change made manually to the TeamCity project settings.

co-authored-by: @Mark-McCracken 

