### PR TITLE
Bump Eventbrite consents lambda to Java 11

### DIFF
--- a/eventbrite-consents/README.md
+++ b/eventbrite-consents/README.md
@@ -1,6 +1,6 @@
 # Eventbrite consents sync Lambda
 
-The service is a Scala lambda which sends emails to users who tick the 'hear more about guardian news and media' check box in Evenbrite.
+The service is a Scala lambda which sends emails to users who tick the 'hear more about guardian news and media' check box in Eventbrite.
 
 ## Lambda Details
 

--- a/eventbrite-consents/cloud-formation.yaml
+++ b/eventbrite-consents/cloud-formation.yaml
@@ -72,7 +72,7 @@ Resources:
           syncFrequencyHours: !FindInMap [SyncFrequencyMap, values, syncFrequencyHours]
           isDebug: !FindInMap [IsDebugMap, !Ref Stage, value]
       Handler: com.gu.identity.eventbriteconsents.Lambda::handler
-      Runtime: java8.al2
+      Runtime: java11
       CodeUri:
         Bucket: identity-lambda
         Key: !Sub identity/${Stage}/eventbrite-consents-lambda/main.jar


### PR DESCRIPTION
Tested in Dev with `isDebug = true`
Teamcity also updated to build with Java 11.

https://trello.com/c/ceUg05jM/4360-upgrade-all-scala-lambdas-to-java-11
