### PR TITLE
Bump Formstack consents lambda to Java 11

### DIFF
--- a/formstack-consents/cloud-formation.yaml
+++ b/formstack-consents/cloud-formation.yaml
@@ -51,7 +51,7 @@ Resources:
           idapiAccessToken: !Sub ${IdentityAPIKey}
           formstackSharedSecret: !Sub ${FormstackSharedSecret}
       Handler: com.gu.identity.formstackconsents.Lambda::handler
-      Runtime: java8.al2
+      Runtime: java11
       CodeUri:
         Bucket: identity-lambda
         Key: !Sub identity/${Stage}/formstack-consents-lambda/main.jar


### PR DESCRIPTION
Tested in Code and Cloudwatch log output looks as expected.

Teamcity also updated to build with Java 11.

https://trello.com/c/ceUg05jM/4360-upgrade-all-scala-lambdas-to-java-11