### PR TITLE
Bump payment failure lambda to Java 11

### DIFF
--- a/payment-failure/cloud-formation.yaml
+++ b/payment-failure/cloud-formation.yaml
@@ -102,7 +102,7 @@ Resources:
       FunctionName: !Sub PaymentFailureLambda-${Stage}
       Handler: com.gu.identity.paymentfailure.Lambda::handler
       Role: !GetAtt PaymentFailureLambdaRole.Arn
-      Runtime: java8.al2
+      Runtime: java11
       Timeout: 30
       MemorySize: 1024
 


### PR DESCRIPTION
Tested in Code and Cloudwatch log output looks as expected.

Teamcity also updated to build with Java 11.

https://trello.com/c/ceUg05jM/4360-upgrade-all-scala-lambdas-to-java-11
