### PR TITLE
add TheGuideGlastonbury2024 Newsletter object with formId 5296655

### DIFF
--- a/formstack-consents/src/main/scala/com/gu/identity/formstackconsents/IdentityClient.scala
+++ b/formstack-consents/src/main/scala/com/gu/identity/formstackconsents/IdentityClient.scala
@@ -13,7 +13,7 @@ import scala.util.Try
 
 class IdentityClient(config: Config) extends StrictLogging {
 
-  val newsletters: List[Newsletter] = List(Traveller, Students, Universities, Teachers, Masterclasses, SocietyWeekly, EdinburghFestivalDataCollection, EventMarketingConsentCollection)
+  val newsletters: List[Newsletter] = List(Traveller, Students, Universities, Teachers, Masterclasses, SocietyWeekly, EdinburghFestivalDataCollection, EventMarketingConsentCollection, TheGuideGlastonbury2024)
 
   val optInForms: List[MarketingConsent] = List(EventMarketingConsentCollection)
 

--- a/formstack-consents/src/main/scala/com/gu/identity/formstackconsents/Newsletter.scala
+++ b/formstack-consents/src/main/scala/com/gu/identity/formstackconsents/Newsletter.scala
@@ -23,7 +23,7 @@ case object Traveller extends Newsletter {
 case object TheGuideGlastonbury2024 extends Newsletter {
   val formId = "5296655"
   val listType = "set-lists"
-  val consent = "the-guide"
+  val consent = "the-guide-staying-in"
 }
 
 case object Students extends Newsletter {

--- a/formstack-consents/src/main/scala/com/gu/identity/formstackconsents/Newsletter.scala
+++ b/formstack-consents/src/main/scala/com/gu/identity/formstackconsents/Newsletter.scala
@@ -14,6 +14,18 @@ case object Traveller extends Newsletter {
   val consent = "guardian-traveller"
 }
 
+// Being used on a promotional competetion to win tickets to Glastonbury 2024. Includes a name
+// field as well as email. All entrants will be signed up for The Guide newsletter.
+// The for will be embeded on an article page behind this custom URL: 
+// https://www.theguardian.com/glastonbury-prize-draw-2024
+// (as of 19/05/2023, the custom URL has been set up, but the the article is not built yet.)
+// form url https://guardiannewsandmedia.formstack.com/forms/the_guide_glastonbury_competition
+case object TheGuideGlastonbury2024 extends Newsletter {
+  val formId = "5296655"
+  val listType = "set-lists"
+  val consent = "the-guide"
+}
+
 case object Students extends Newsletter {
   val formId = "2946711"
   val listType = "set-lists"


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Adds a new Newsletter Object to the list of formstack forms supported to the formstack-consents lambda.


## How can we measure success?

When merged, completing this formstack form will trigger  an identity API request to sign the email address up to the newsletter with the identityName "the-guide-staying-in":
https://guardiannewsandmedia.formstack.com/forms/the_guide_glastonbury_competition

The webhook has been added to the form.

