### PR TITLE
increase the default timeouts for formstack requests

### DIFF
--- a/formstack-baton-requests/src/main/scala/com/gu/identity/formstackbatonrequests/services/FormstackService.scala
+++ b/formstack-baton-requests/src/main/scala/com/gu/identity/formstackbatonrequests/services/FormstackService.scala
@@ -9,7 +9,7 @@ import com.gu.identity.formstackbatonrequests.{FormstackAccountToken, PerformLam
 import com.typesafe.scalalogging.LazyLogging
 import io.circe.Decoder
 import io.circe.parser.decode
-import scalaj.http.{BaseHttp, Http, HttpResponse}
+import scalaj.http.{BaseHttp, Http, HttpOptions, HttpResponse}
 
 trait FormstackRequestService {
   def accountFormsForGivenPage(page: Int, accountToken: FormstackAccountToken): Either[Throwable, FormsResponse]
@@ -25,7 +25,14 @@ sealed trait FormstackSkippableError extends Throwable
 case class FormstackDecryptionError(message: String) extends FormstackSkippableError
 case class FormstackAuthError(message: String) extends FormstackSkippableError
 
-class FormstackService(http:BaseHttp = Http) extends FormstackRequestService with LazyLogging {
+object CustomHttp extends BaseHttp(
+  options = Seq(
+    HttpOptions.connTimeout(2000),
+    HttpOptions.readTimeout(10000),
+    HttpOptions.followRedirects(false)
+  )
+)
+class FormstackService(http:BaseHttp = CustomHttp) extends FormstackRequestService with LazyLogging {
 
 import FormstackService._
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
We are getting some Formstack Api calls timing out in `formstack-baton-requests` which causes the whole process to fail.
This PR increases the default timeouts of the http client library we use so that the Formstack api has more time to respond.

## How to test
As always the problem with this is that we don't have a Formstack code environment,  the `CODE` version of this mocks Formstack calls. To test before merging we have [this](https://github.com/guardian/identity-processes/blob/main/formstack-baton-requests/src/local/com/gu/identity/formstackbatonrequests/services/FormstackRequestServiceProdLocalRun.scala)  main method we can run on our local computer to trigger the Formstack service with `PROD` credentials. It's not ideal and kind of risky, but that is what we are using in the absence of a Formstack environment that is safe to use in `CODE`.

I edited this test code in my computer (not pushed)  to call `FormstackService.formSubmissionsForGivenPage` instead, with the same parameters that is causing the timeout in `PROD`. I was able to reproduce the timeout response with the current code in main and after these changes I get a successful response from the api.

Once this is merged we can just trigger a SAR (the user makes no difference so we can use a test email)  and it should not timeout instantly on the client side. Given that the process hasn't ran successfully for a few days we might encounter the known issue of the lambda timing out after 15 minutes when it has too many submissions to catch up on.