### PR TITLE
Migrate from TeamCity to GitHub Actions

### DIFF
--- a/.github/workflows/ci-eventbrite-consents.yml
+++ b/.github/workflows/ci-eventbrite-consents.yml
@@ -1,0 +1,54 @@
+name: CI - Eventbrite consents sync lambda
+
+on:
+  pull_request:
+    paths:
+      - 'eventbrite-consents/**'
+      - '.github/workflows/ci-eventbrite-consents.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'eventbrite-consents/**'
+      - '.github/workflows/ci-eventbrite-consents.yml'
+  workflow_dispatch:
+
+jobs:
+  CI:
+    runs-on: ubuntu-latest
+
+    permissions:
+      # required by aws-actions/configure-aws-credentials
+      id-token: write
+      contents: read        
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Java 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'corretto'
+          cache: 'sbt'
+
+      - name: Test and build 
+        run: sbt clean compile test assembly
+        working-directory: eventbrite-consents
+
+      - uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+          aws-region: eu-west-1
+
+      - name: Upload to RiffRaff
+        uses: guardian/actions-riff-raff@v2
+        with:
+          projectName: eventbrite-consents-lambda
+          buildNumberOffset: 82
+          configPath: eventbrite-consents/riff-raff.yaml
+          contentDirectories: |
+            eventbrite-consents-lambda:
+              - eventbrite-consents/target/scala-2.12/main.jar
+            eventbrite-consents-cfn:
+              - eventbrite-consents/cloud-formation.yaml

--- a/.github/workflows/deploy-formstack.yml
+++ b/.github/workflows/deploy-formstack.yml
@@ -1,8 +1,15 @@
 on:
   pull_request:
+    paths:
+      - 'formstack-baton-requests/**'
+      - '.github/workflows/deploy-formstack.yml'
   push:
     branches:
       - main
+    paths:
+      - 'formstack-baton-requests/**'
+      - '.github/workflows/deploy-formstack.yml'
+
 env:
   DIRECTORY_NAME: formstack-baton-requests
 

--- a/eventbrite-consents/build.sbt
+++ b/eventbrite-consents/build.sbt
@@ -34,9 +34,3 @@ assembly / assemblyMergeStrategy := {
     val oldStrategy = (assembly / assemblyMergeStrategy).value
     oldStrategy(x)
 }
-
-enablePlugins(RiffRaffArtifact)
-riffRaffPackageType := assembly.value
-riffRaffUploadArtifactBucket := Option("riffraff-artifact")
-riffRaffUploadManifestBucket := Option("riffraff-builds")
-riffRaffArtifactResources += (file("cloud-formation.yaml") -> "eventbrite-consents-cfn/cloud-formation.yaml")

--- a/eventbrite-consents/project/plugins.sbt
+++ b/eventbrite-consents/project/plugins.sbt
@@ -1,3 +1,1 @@
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.18")
-
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")


### PR DESCRIPTION
- Replace existing TeamCity CI behaviour with a GitHub Actions workflow
- Remove the RiffRaffArtifact plugin
- Limit the existing workflow for the formstack consents lambda to only run when its files are updated

## Testing

- [x] Test lambda in DEV