### PR TITLE
formstack-consents-lambda: migrate TeamCity to GitHub Actions

### DIFF
--- a/.github/workflows/ci-formstack-consents.yml
+++ b/.github/workflows/ci-formstack-consents.yml
@@ -1,0 +1,54 @@
+name: CI - Formstack consents lambda
+
+on:
+  pull_request:
+    paths:
+      - 'formstack-consents/**'
+      - '.github/workflows/ci-formstack-consents.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'formstack-consents/**'
+      - '.github/workflows/ci-formstack-consents.yml'
+  workflow_dispatch:
+
+jobs:
+  CI:
+    runs-on: ubuntu-latest
+
+    permissions:
+      # required by aws-actions/configure-aws-credentials
+      id-token: write
+      contents: read        
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Java 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'corretto'
+          cache: 'sbt'
+
+      - name: Test and build 
+        run: sbt clean compile test assembly
+        working-directory: formstack-consents
+
+      - uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+          aws-region: eu-west-1
+
+      - name: Upload to RiffRaff
+        uses: guardian/actions-riff-raff@v2
+        with:
+          projectName: formstack-consents-lambda
+          buildNumberOffset: 108
+          configPath: formstack-consents/riff-raff.yaml
+          contentDirectories: |
+            formstack-consents-lambda:
+              - formstack-consents/target/scala-2.12/main.jar
+            formstack-consents-cfn:
+              - formstack-consents/cloud-formation.yaml

--- a/formstack-consents/build.sbt
+++ b/formstack-consents/build.sbt
@@ -40,9 +40,3 @@ assembly / assemblyMergeStrategy := {
     val oldStrategy = (assembly / assemblyMergeStrategy).value
     oldStrategy(x)
 }
-
-enablePlugins(RiffRaffArtifact)
-riffRaffPackageType := assembly.value
-riffRaffUploadArtifactBucket := Option("riffraff-artifact")
-riffRaffUploadManifestBucket := Option("riffraff-builds")
-riffRaffArtifactResources += (file("cloud-formation.yaml") -> "formstack-consents-cfn/cloud-formation.yaml")

--- a/formstack-consents/project/plugins.sbt
+++ b/formstack-consents/project/plugins.sbt
@@ -1,3 +1,1 @@
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.18")
-
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")


### PR DESCRIPTION
- Replace existing TeamCity CI behaviour with a GitHub Actions workflow
- Replace the deprecated [sbt-riffraff-artifact](https://github.com/guardian/sbt-riffraff-artifact) with [actions-riff-raff](https://github.com/guardian/actions-riff-raff/).

## Testing

- [x] Test in CODE