### PR TITLE
use eastern time on formstack call

### DIFF
--- a/formstack-baton-requests/src/main/scala/com/gu/identity/formstackbatonrequests/aws/DynamoClient.scala
+++ b/formstack-baton-requests/src/main/scala/com/gu/identity/formstackbatonrequests/aws/DynamoClient.scala
@@ -1,8 +1,7 @@
 package com.gu.identity.formstackbatonrequests.aws
 
 import java.time.format.DateTimeFormatter
-import java.time.LocalDateTime
-
+import java.time.{LocalDateTime, ZoneId, ZoneOffset}
 import com.typesafe.scalalogging.LazyLogging
 import com.amazonaws.services.dynamodbv2.{AmazonDynamoDB, AmazonDynamoDBClient}
 import com.gu.scanamo.Scanamo
@@ -10,6 +9,7 @@ import com.github.t3hnar.bcrypt._
 import com.gu.scanamo.syntax._
 import cats.implicits._
 import com.amazonaws.services.dynamodbv2.model.{BatchWriteItemResult, DeleteItemResult, ProvisionedThroughput, UpdateTableRequest, UpdateTableResult}
+import com.gu.identity.formstackbatonrequests.aws.SubmissionTableUpdateDate.formatter
 import com.gu.identity.formstackbatonrequests.sar.SubmissionIdEmail
 
 import scala.util.Try
@@ -22,7 +22,12 @@ trait DynamoClient {
   def deleteUserSubmissions(submissionIdsAndEmails: List[SubmissionIdEmail], salt: String, submissionsTableName: String): Either[Throwable, List[DeleteItemResult]]
 }
 
-case class SubmissionTableUpdateDate(formstackSubmissionTableMetadata: String, date: String)
+case class SubmissionTableUpdateDate(formstackSubmissionTableMetadata: String, date: String){
+  def toEasternTime:String = {
+    val utcDate = LocalDateTime.parse(date, formatter).atZone(ZoneOffset.UTC)
+    utcDate.withZoneSameInstant(ZoneId.of("America/New_York")).format(formatter)
+  }
+}
 
 object SubmissionTableUpdateDate {
   val formatter: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")

--- a/formstack-baton-requests/src/main/scala/com/gu/identity/formstackbatonrequests/services/DynamoUpdateService.scala
+++ b/formstack-baton-requests/src/main/scala/com/gu/identity/formstackbatonrequests/services/DynamoUpdateService.scala
@@ -71,7 +71,7 @@ case class DynamoUpdateService(
       response <- formstackClient.formSubmissionsForGivenPage(
         page = submissionPage,
         formId = form.id,
-        minTime = lastUpdate,
+        minTimeUTC = lastUpdate,
         encryptionPassword = config.encryptionPassword,
         accountToken = token
       ).left.flatMap(skipSafeErrors)

--- a/formstack-baton-requests/src/main/scala/com/gu/identity/formstackbatonrequests/services/FormstackService.scala
+++ b/formstack-baton-requests/src/main/scala/com/gu/identity/formstackbatonrequests/services/FormstackService.scala
@@ -55,7 +55,7 @@ import FormstackService._
   override def formSubmissionsForGivenPage(
     page: Int,
     formId: String,
-    minTime: SubmissionTableUpdateDate,
+    minTimeUTC: SubmissionTableUpdateDate,
     encryptionPassword: String,
     accountToken: FormstackAccountToken): Either[Throwable, FormSubmissions] = {
     val response = http(s"https://www.formstack.com/api/v2/form/$formId/submission.json")
@@ -72,7 +72,8 @@ import FormstackService._
           ("data", "true"),
           ("expand_data", "true"),
           ("sort", "DESC"),
-          ("min_time", minTime.date)
+          // this api call expects eastern time zone, see https://developers.formstack.com/reference/form-id-submission-get
+          ("min_time", minTimeUTC.toEasternTime)
         )
       ).asString
 

--- a/formstack-baton-requests/src/main/scala/com/gu/identity/formstackbatonrequests/services/FormstackService.scala
+++ b/formstack-baton-requests/src/main/scala/com/gu/identity/formstackbatonrequests/services/FormstackService.scala
@@ -13,7 +13,7 @@ import scalaj.http.{BaseHttp, Http, HttpOptions, HttpResponse}
 
 trait FormstackRequestService {
   def accountFormsForGivenPage(page: Int, accountToken: FormstackAccountToken): Either[Throwable, FormsResponse]
-  def formSubmissionsForGivenPage(page: Int, formId: String, minTime: SubmissionTableUpdateDate, encryptionPassword: String, accountToken: FormstackAccountToken): Either[Throwable, FormSubmissions]
+  def formSubmissionsForGivenPage(page: Int, formId: String, minTimeUTC: SubmissionTableUpdateDate, encryptionPassword: String, accountToken: FormstackAccountToken): Either[Throwable, FormSubmissions]
   def submissionData(requestEmail:String, submissionIdEmails: List[SubmissionIdEmail], config: PerformLambdaConfig): Either[Throwable, List[FormstackSubmissionQuestionAnswer]]
   def deleteUserData(requestEmail:String, submissionIdEmails: List[SubmissionIdEmail], config: PerformLambdaConfig): Either[Throwable, List[SubmissionDeletionReponse]]
 }

--- a/formstack-baton-requests/src/main/scala/com/gu/identity/formstackbatonrequests/services/stub/FormstackServiceStub.scala
+++ b/formstack-baton-requests/src/main/scala/com/gu/identity/formstackbatonrequests/services/stub/FormstackServiceStub.scala
@@ -13,7 +13,7 @@ class FormstackServiceStub(
   submissionDataResponse: Either[Throwable, List[FormstackSubmissionQuestionAnswer]],
   deleteDataResponse: Either[Throwable, List[SubmissionDeletionReponse]]) extends FormstackRequestService {
   override def accountFormsForGivenPage(page: Int, accountToken: FormstackAccountToken): Either[Throwable, FormsResponse] = accountFormsForGivenPageResponse
-  override def formSubmissionsForGivenPage(page: Int, formId: String, minTime: SubmissionTableUpdateDate, encryptionPassword: String, accountToken: FormstackAccountToken): Either[Throwable, FormSubmissions] = formSubmissionsForGivenPageResponse
+  override def formSubmissionsForGivenPage(page: Int, formId: String, minTimeUTC: SubmissionTableUpdateDate, encryptionPassword: String, accountToken: FormstackAccountToken): Either[Throwable, FormSubmissions] = formSubmissionsForGivenPageResponse
   override def submissionData(requestEmail:String, submissionIdEmails: List[SubmissionIdEmail], config: PerformLambdaConfig): Either[Throwable, List[FormstackSubmissionQuestionAnswer]] = submissionDataResponse
   override def deleteUserData(requestEmail:String, submissionIdEmails: List[SubmissionIdEmail], config: PerformLambdaConfig): Either[Throwable, List[SubmissionDeletionReponse]] = deleteDataResponse
 }

--- a/formstack-baton-requests/src/test/scala/com/gu/identity/formstackbatonrequests/aws/SubmissionTableUpdateDateSpec.scala
+++ b/formstack-baton-requests/src/test/scala/com/gu/identity/formstackbatonrequests/aws/SubmissionTableUpdateDateSpec.scala
@@ -1,0 +1,18 @@
+package com.gu.identity.formstackbatonrequests.aws
+
+import org.scalatest.{FreeSpec, Matchers}
+
+import java.time.LocalDateTime
+
+class SubmissionTableUpdateDateSpec extends FreeSpec with Matchers {
+  "SubmissionTableUpdateDate" - {
+    "should convert to eastern by applying an offset of 5 hours for winter dates" in {
+      val utcDate = SubmissionTableUpdateDate("unused_metadata", "2023-01-13 12:45:31")
+      utcDate.toEasternTime shouldBe "2023-01-13 07:45:31"
+    }
+    "should convert to eastern by applying an offset of 4 hours for summer dates" in {
+      val utcDate = SubmissionTableUpdateDate("unused_metadata", "2023-08-09 16:54:31")
+      utcDate.toEasternTime shouldBe "2023-08-09 12:54:31"
+    }
+  }
+}


### PR DESCRIPTION
## What does this change?

We are currently using the GET /form/:id/submission endpoint in the Formstack APi and providing the `min_time`  parameter to fetch the submissions that happened since the last time this process runs.
The problem is that this api call expects this parameter to be in USA eastern time (apparently not Eastern Standard time, which ignores daylight savings).
Even though the dates are returned in uk time (or maybe in the time zone the form is  configured to use), the filtering itself must be provided in usa eastern time.

See documentation here: https://developers.formstack.com/reference/form-id-submission-get.

