### PR TITLE
formstack baton request gha fixes

### DIFF
--- a/.github/workflows/deploy-formstack.yml
+++ b/.github/workflows/deploy-formstack.yml
@@ -1,3 +1,4 @@
+name: CI - Formstack Baton Requests
 on:
   pull_request:
     paths:
@@ -9,6 +10,7 @@ on:
     paths:
       - 'formstack-baton-requests/**'
       - '.github/workflows/deploy-formstack.yml'
+  workflow_dispatch:
 
 env:
   DIRECTORY_NAME: formstack-baton-requests
@@ -39,7 +41,7 @@ jobs:
       - name: Upload to Riff Raff
         uses: guardian/actions-riff-raff@v2
         with:
-          app: formstack-baton-requests
+          projectName: formstack-baton-requests
           buildNumberOffset: 274
           configPath: ./${{env.DIRECTORY_NAME}}/riff-raff.yaml
           contentDirectories: |


### PR DESCRIPTION
The main reason for this pr is that the continuous deployment is not triggering because the project name has changed.
Instead of changing the expected project name on riff-raff we will fix it here to match the rest of the projects in the repo.
before :
<img width="543" alt="image" src="https://github.com/guardian/identity-processes/assets/15324270/5906113f-46b3-4be6-881a-d33a5b66b39a">

after:
<img width="543" alt="image" src="https://github.com/guardian/identity-processes/assets/15324270/a4edecc3-606f-4bef-a1c9-76029535759c">


I also made a couple other changes to match the other projects in the repo:
- add a manual trigger for the build 
- give the project a name

It looks like the manual trigger might not show up until you merge the pr?
