### PR TITLE
update dynamodb settings

### DIFF
--- a/formstack-baton-requests/cloud-formation.yaml
+++ b/formstack-baton-requests/cloud-formation.yaml
@@ -599,8 +599,10 @@ Resources:
             Statement:
               - Effect: "Allow"
                 Action: "lambda:InvokeFunction"
-                Resource: "*"
-
+                Resource:
+                  - !GetAtt PerformFormstackSarLambda.Arn
+                  - !GetAtt UpdateDynamoLambda.Arn
+                  - !GetAtt PerformFormstackRerLambda.Arn
   FormstackSar:
     Type: "AWS::StepFunctions::StateMachine"
     Properties:

--- a/formstack-baton-requests/cloud-formation.yaml
+++ b/formstack-baton-requests/cloud-formation.yaml
@@ -39,6 +39,14 @@ Parameters:
 
 Conditions:
   IsProd: !Equals [ !Ref Stage, PROD ]
+Mappings:
+  StageVariables:
+    PROD:
+      SubmissionsTableWriteCapacityUnits: 20
+      SubmissionsTableReadCapacityUnits: 5
+    CODE:
+      SubmissionsTableWriteCapacityUnits: 1
+      SubmissionsTableReadCapacityUnits: 1
 
 Resources:
   TopicSendEmail:
@@ -153,6 +161,7 @@ Resources:
     Type: AWS::DynamoDB::Table
     Properties:
       TableName: !Ref SubmissionsTableName
+      DeletionProtectionEnabled: true
       AttributeDefinitions:
         - AttributeName: email
           AttributeType: S
@@ -164,13 +173,14 @@ Resources:
         - AttributeName: submissionId
           KeyType: RANGE
       ProvisionedThroughput:
-        ReadCapacityUnits: 5
-        WriteCapacityUnits: 20
+        ReadCapacityUnits: !FindInMap [StageVariables, !Ref 'Stage', SubmissionsTableReadCapacityUnits]
+        WriteCapacityUnits: !FindInMap [StageVariables, !Ref 'Stage', SubmissionsTableWriteCapacityUnits]
 
   FormstackSubmissionsLastUpdated:
     Type: AWS::DynamoDB::Table
     Properties:
       TableName: !Ref LastUpdatedTableName
+      DeletionProtectionEnabled: true
       AttributeDefinitions:
         - AttributeName: formstackSubmissionTableMetadata
           AttributeType: S


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
I noticed the code dynamodb table has the same capacity as the prod but it  is barely used. There's no need to pay $11 a month when we can pay $0.60 
Also I enabled deletion protection on the tables just because it's good practice

## Test

I deployed these changes to code and I can see the settings being applied correctly.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
