### PR TITLE
Backup formstack submissions dynamo tables

### DIFF
--- a/formstack-baton-requests/cloud-formation.yaml
+++ b/formstack-baton-requests/cloud-formation.yaml
@@ -175,6 +175,9 @@ Resources:
       ProvisionedThroughput:
         ReadCapacityUnits: !FindInMap [StageVariables, !Ref 'Stage', SubmissionsTableReadCapacityUnits]
         WriteCapacityUnits: !FindInMap [StageVariables, !Ref 'Stage', SubmissionsTableWriteCapacityUnits]
+      Tags:
+        - Key: devx-backup-enabled
+          Value: true
 
   FormstackSubmissionsLastUpdated:
     Type: AWS::DynamoDB::Table
@@ -190,6 +193,9 @@ Resources:
       ProvisionedThroughput:
         ReadCapacityUnits: 1
         WriteCapacityUnits: 1
+      Tags:
+        - Key: devx-backup-enabled
+          Value: true
 
   PerformFormstackSarLambdaRole:
     Type: AWS::IAM::Role


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This PR allows us to start backing up the `formstack-submission-ids` and `formstack-submission-last-updated` DynamoDB tables using https://github.com/guardian/aws-backup. For more details on this project see [this doc](https://docs.google.com/document/d/11EZtuVHCnjavE9AYLroiuDUsMzbp2ulFBtj4VkyCKNc/edit) and this [audit](https://docs.google.com/spreadsheets/d/1gNh_yQ3GVo_dVAemgZfRZM_MaQxep6_x-hzrhvVBGHY/edit#gid=1523470588) that @guardian/devx-reliability have been working on with Heads of Engineering & EMs.

## How to test

I've [deployed this to CODE](https://riffraff.gutools.co.uk/deployment/view/cd3d00cf-1abc-450d-b2a2-a706dbc620dc) first, and will check if backups are being done correctly.

## How can we measure success?

Improved time to recovery from future disasters!

## Have we considered potential risks?

Since this project has active CD, I think there's little risk that this change will do anything else except add the tags to the tables.
