### PR TITLE
Map a new Formstack form to a new consent

### DIFF
--- a/formstack-consents/src/main/scala/com/gu/identity/formstackconsents/IdentityClient.scala
+++ b/formstack-consents/src/main/scala/com/gu/identity/formstackconsents/IdentityClient.scala
@@ -13,7 +13,18 @@ import scala.util.Try
 
 class IdentityClient(config: Config) extends StrictLogging {
 
-  val newsletters: List[Newsletter] = List(Traveller, Students, Universities, Teachers, Masterclasses, SocietyWeekly, EdinburghFestivalDataCollection, EventMarketingConsentCollection, TheGuideGlastonbury2024)
+  val newsletters: List[Newsletter] = List(
+    Traveller,
+    Students,
+    Universities,
+    Teachers,
+    Masterclasses,
+    SocietyWeekly,
+    EdinburghFestivalDataCollection,
+    EventMarketingConsentCollection,
+    TheGuideGlastonbury2024,
+    FeastAppBetaSignup,
+  )
 
   val optInForms: List[MarketingConsent] = List(EventMarketingConsentCollection)
 

--- a/formstack-consents/src/main/scala/com/gu/identity/formstackconsents/Newsletter.scala
+++ b/formstack-consents/src/main/scala/com/gu/identity/formstackconsents/Newsletter.scala
@@ -65,7 +65,7 @@ case object EdinburghFestivalDataCollection extends Newsletter {
 }
 
 case object FeastAppBetaSignup extends Newsletter {
-  val formId = "TBD"
+  val formId = "5581302"
   val listType = "set-consents"
   val consent = "feast_app_beta"
 }

--- a/formstack-consents/src/main/scala/com/gu/identity/formstackconsents/Newsletter.scala
+++ b/formstack-consents/src/main/scala/com/gu/identity/formstackconsents/Newsletter.scala
@@ -64,6 +64,12 @@ case object EdinburghFestivalDataCollection extends Newsletter {
   val consent = "supporter"
 }
 
+case object FeastAppBetaSignup extends Newsletter {
+  val formId = "TBD"
+  val listType = "set-consents"
+  val consent = "feast_app_beta"
+}
+
 // Some marketing Forms have an opt in checkbox for consent collection.
 // Formstack form can be setup with conditional logic to trigger the lambda webhook,
 // but we want tp check again when the submission is decoded as a precaution.


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Map a new Formstack form to a [new consent](https://github.com/guardian/identity/pull/2482). This is so that we can use Formstack to collect email addresses for users who want to opt-in to Feast app beta updates.

The flow will be:

1. User follows link to Composer page which has the Formstack form embedded.
2. User enters email address and submits the form
3. Formstack makes a webhook request to the formstack-consents lambda (which in turn makes a request to IDAPI which triggers the confirmation email)
4. User receives confirmation email
5. Consent is set for user

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

I think the only way to test this is to try it out from the real Formstack form once this change is live.

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
