### PR TITLE
Give Baton Formstack SAR processor 10 minutes to process each form

### DIFF
--- a/formstack-baton-requests/riff-raff.yaml
+++ b/formstack-baton-requests/riff-raff.yaml
@@ -11,7 +11,7 @@ deployments:
   formstack-baton-requests:
     type: aws-lambda
     parameters:
-      bucket: identity-lambda
+      bucketSsmLookup: true
       functionNames: [
         formstack-baton-sar-lambda-,
         formstack-baton-perform-sar-lambda-,

--- a/formstack-baton-requests/src/main/scala/com/gu/identity/formstackbatonrequests/services/DynamoUpdateService.scala
+++ b/formstack-baton-requests/src/main/scala/com/gu/identity/formstackbatonrequests/services/DynamoUpdateService.scala
@@ -160,7 +160,7 @@ case class DynamoUpdateService(
         val errors = formResults.collect { case Left(err) => err }
         if (errors.nonEmpty) {
           Left(new Exception(errors.toString))
-        } else if (count < response.total & context.getRemainingTimeInMillis > 300000) {
+        } else if (count < response.total & context.getRemainingTimeInMillis > 600000) {
           updateSubmissionsTable(formsPage + 1, minTimeUTC, maxTimeUTC, count + FormstackService.formResultsPerPage, token, context)
         } else if (count < response.total) {
           Right(UpdateStatus(completed = false, Some(formsPage + 1), Some(count + FormstackService.formResultsPerPage), token))

--- a/formstack-baton-requests/src/test/scala/com/gu/identity/formstackbatonrequests/services/DynamoUpdateServiceSpec.scala
+++ b/formstack-baton-requests/src/test/scala/com/gu/identity/formstackbatonrequests/services/DynamoUpdateServiceSpec.scala
@@ -45,8 +45,8 @@ class DynamoUpdateServiceSpec
       }
     }
 
-    val millisLongerThan30s = 300001
-    val millisLessThan30s = 290000
+    val millisLongerThan10m = 600001
+    val millisLessThan10m = 599999
 
     val dummyFormsPage = 1
     val dummyCount = 0
@@ -90,7 +90,7 @@ class DynamoUpdateServiceSpec
       (mockContext.getRemainingTimeInMillis _)
         .when()
         .anyNumberOfTimes()
-        .returns(millisLongerThan30s)
+        .returns(millisLongerThan10m)
 
       val expectedUpdateStatus = UpdateStatus(
         completed = true,
@@ -109,7 +109,7 @@ class DynamoUpdateServiceSpec
       )
       statusUpdate.right.value shouldBe expectedUpdateStatus
     }
-    "successfully calls updateSubmissionsTable with > 30s of lambda runtime available" in {
+    "successfully calls updateSubmissionsTable with > 10m of lambda runtime available" in {
       val dynamoUpdateService: DynamoUpdateService = DynamoUpdateService(
         formstackClient = FormstackServiceStub.withSuccessResponse,
         dynamoClient = DynamoClientStub.withSuccessResponse,
@@ -121,7 +121,7 @@ class DynamoUpdateServiceSpec
       (mockContext.getRemainingTimeInMillis _)
         .when()
         .anyNumberOfTimes()
-        .returns(millisLongerThan30s)
+        .returns(millisLongerThan10m)
 
       val expectedUpdateStatus = UpdateStatus(
         completed = true,
@@ -141,7 +141,7 @@ class DynamoUpdateServiceSpec
       statusUpdate.right.value shouldBe expectedUpdateStatus
     }
 
-    "successfully calls updateSubmissionsTable with < 30s of lambda runtime available" in {
+    "successfully calls updateSubmissionsTable with < 10m of lambda runtime available" in {
       val dynamoUpdateService: DynamoUpdateService = DynamoUpdateService(
         formstackClient = FormstackServiceStub.withSuccessResponse,
         dynamoClient = DynamoClientStub.withSuccessResponse,
@@ -153,7 +153,7 @@ class DynamoUpdateServiceSpec
       (mockContext.getRemainingTimeInMillis _)
         .when()
         .anyNumberOfTimes()
-        .returns(millisLessThan30s)
+        .returns(millisLessThan10m)
 
       val expectedUpdateStatus = UpdateStatus(
         completed = false,
@@ -186,7 +186,7 @@ class DynamoUpdateServiceSpec
       (mockContext.getRemainingTimeInMillis _)
         .when()
         .anyNumberOfTimes()
-        .returns(millisLessThan30s)
+        .returns(millisLessThan10m)
 
       val statusUpdate = dynamoUpdateService.updateSubmissionsTable(
         formsPage = dummyFormsPage,
@@ -222,7 +222,7 @@ class DynamoUpdateServiceSpec
       (mockContext.getRemainingTimeInMillis _)
         .when()
         .anyNumberOfTimes()
-        .returns(millisLessThan30s)
+        .returns(millisLessThan10m)
 
       val statusUpdate = dynamoUpdateService.updateSubmissionsTable(
         formsPage = dummyFormsPage,
@@ -257,7 +257,7 @@ class DynamoUpdateServiceSpec
       (mockContext.getRemainingTimeInMillis _)
         .when()
         .anyNumberOfTimes()
-        .returns(millisLessThan30s)
+        .returns(millisLessThan10m)
 
       val statusUpdate = dynamoUpdateService.updateSubmissionsTable(
         formsPage = dummyFormsPage,
@@ -311,7 +311,7 @@ class DynamoUpdateServiceSpec
       (mockContext.getRemainingTimeInMillis _)
         .when()
         .anyNumberOfTimes()
-        .returns(millisLongerThan30s)
+        .returns(millisLongerThan10m)
 
       val statusUpdate = dynamoUpdateService.updateSubmissionsTable(
         formsPage = dummyFormsPage,


### PR DESCRIPTION
# Problem
Some forms with many submissions are taking too long to process.  Even though the job is running in a state machine so that it will repeat until it's complete, the individual forms are being processed as a single batch within a lambda.  This means that if a single form takes too long, the lambda will time out and the whole state machine will fail.

# Solution implemented
Before processing a form, the lambda checks how much time it has left.  This value is set to 5 minutes.  But the logs show one form is consistently taking more than 5 minutes to process.  By increasing the time needed to a maximum of 10 minutes per form, we should see the lambda finish its work and then the next lambda should have time to process the form fully.
