### PR TITLE
comment out formstack update step functions

### DIFF
--- a/formstack-baton-requests/cloud-formation.yaml
+++ b/formstack-baton-requests/cloud-formation.yaml
@@ -630,59 +630,65 @@ Resources:
                 Action: "lambda:InvokeFunction"
                 Resource:
                   - !GetAtt UpdateDynamoLambda.Arn
-
-  FormstackUpdateDynamo:
-    Type: "AWS::StepFunctions::StateMachine"
-    Properties:
-      StateMachineName: !Join ['-', ['FormstackUpdateDynamo', !Ref Stage]]
-      DefinitionString:
-        !Sub
-        - |-
-          {
-            "Comment": "Triggered manually if we need to update the Formstack dynamodb table in smaller increments. Used if the full update performed by the other state machines is so big that it causes errors.",
-            "StartAt": "AddParams",
-            "States": {
-               "AddParams": {
-                    "Type": "Pass",
-                    "Parameters": {
-                      "timeOfStart.$": "States.ArrayGetItem(States.StringSplit($$.Execution.StartTime, 'Z'),0)",
-                      "requestType": "SAR",
-                      "initiationReference": "updateDynamo",
-                      "subjectEmail": "unused_email@guardian.co.uk",
-                      "dataProvider": "formstack",
-                      "accountNumber": 1,
-                      "formPage": 1,
-                      "count": 25,
-                      "maxUpdateSeconds.$": "$.maxUpdateSeconds"
-                    },
-                    "Next": "UpdateDynamoWithAccountOne"
-                  },
-               "UpdateDynamoWithAccountOne": {
-                 "Type": "Task",
-                 "Resource": "${updateLambdaArn}",
-                 "Next": "CheckAccountOneUpdateCompletion"
-               },
-               "CheckAccountOneUpdateCompletion": {
-                 "Type": "Choice",
-                 "Choices": [
-                   {
-                     "Variable": "$.status",
-                     "StringEquals": "pending",
-                     "Next": "UpdateDynamoWithAccountOne"
-                   }
-                 ],
-                 "Default": "Done"
-               },
-          
-              "Done": {
-                "Type": "Pass",
-                "End": true
-              }
-            }
-          }
-        -
-          updateLambdaArn: !GetAtt UpdateDynamoLambda.Arn
-      RoleArn: !GetAtt DynamoUpdateStatesExecutionRole.Arn
+# commented out because a bug needs to be fixed before this is can be used and it's risky to use as it is (can lead to
+# submissions being permanently missed)
+# if the whole execution cannot finish in a single lambda run the maxUpdateSeconds parameter is lost in the next
+# lambda invocation so the "last updated date" in dynamo is brought up to the current timestamp even though submissions
+# in the forms from the first lambda execution were only fetched respecting the maxUpdateSeconds param
+#
+#
+#  FormstackUpdateDynamo:
+#    Type: "AWS::StepFunctions::StateMachine"
+#    Properties:
+#      StateMachineName: !Join ['-', ['FormstackUpdateDynamo', !Ref Stage]]
+#      DefinitionString:
+#        !Sub
+#        - |-
+#          {
+#            "Comment": "Triggered manually if we need to update the Formstack dynamodb table in smaller increments. Used if the full update performed by the other state machines is so big that it causes errors.",
+#            "StartAt": "AddParams",
+#            "States": {
+#               "AddParams": {
+#                    "Type": "Pass",
+#                    "Parameters": {
+#                      "timeOfStart.$": "States.ArrayGetItem(States.StringSplit($$.Execution.StartTime, 'Z'),0)",
+#                      "requestType": "SAR",
+#                      "initiationReference": "updateDynamo",
+#                      "subjectEmail": "unused_email@guardian.co.uk",
+#                      "dataProvider": "formstack",
+#                      "accountNumber": 1,
+#                      "formPage": 1,
+#                      "count": 25,
+#                      "maxUpdateSeconds.$": "$.maxUpdateSeconds"
+#                    },
+#                    "Next": "UpdateDynamoWithAccountOne"
+#                  },
+#               "UpdateDynamoWithAccountOne": {
+#                 "Type": "Task",
+#                 "Resource": "${updateLambdaArn}",
+#                 "Next": "CheckAccountOneUpdateCompletion"
+#               },
+#               "CheckAccountOneUpdateCompletion": {
+#                 "Type": "Choice",
+#                 "Choices": [
+#                   {
+#                     "Variable": "$.status",
+#                     "StringEquals": "pending",
+#                     "Next": "UpdateDynamoWithAccountOne"
+#                   }
+#                 ],
+#                 "Default": "Done"
+#               },
+#
+#              "Done": {
+#                "Type": "Pass",
+#                "End": true
+#              }
+#            }
+#          }
+#        -
+#          updateLambdaArn: !GetAtt UpdateDynamoLambda.Arn
+#      RoleArn: !GetAtt DynamoUpdateStatesExecutionRole.Arn
 
   FormstackSar:
     Type: "AWS::StepFunctions::StateMachine"


### PR DESCRIPTION
This is currently broken and using them could lead to missing submissions so we comment it out to make sure it's not used until it's fixed

The update dynamo state machine is supposed to be the same as the first part of the SAR and RER machines where the dynamo table is updated with the submissions in formstack up to the current date.

The idea is that you can give it a "maxUpdateSeconds" input parameter to bring in the submissions little by little in cases where processing everything in one go causes problems ( Usually it's lambda timeouts but sometimes it's a formstack side issue where the api returns an error telling you to restrict your query more).

**The problem:**
There seems to be a bug that prevents the "maxUpdateSeconds" parameter from being propagated when the step machine has to run the update dynamo lambda more than once. The end result is that the first lambda execution runs for a number of forms respecting the "maxupdateSeconds" param but the rest just try to fetch all submissions up to the current date. 

The biggest problem with this is that the last lambda execution will mark down the last updated timestamp to the current timestamp at the end even though the first lambda execution only fetched a limited amount of submissions (constrained by the "maxUpdateSeconds" parameter). This means that the system will never try to fetch the submissions that were missed in this execution and they would be ignored in any future processing of a baton request.
