### PR TITLE
Pv/snyk 2024 07 31 attempt 2

### DIFF
--- a/formstack-baton-requests/build.sbt
+++ b/formstack-baton-requests/build.sbt
@@ -6,7 +6,7 @@ version := "0.1"
 
 scalaVersion := "2.12.8"
 val circeVersion = "0.13.0"
-val amazonSdkVersion = "1.12.643"
+val amazonSdkVersion = "1.12.767"
 val log4jVersion = "2.17.0"
 
 libraryDependencies ++= Seq(
@@ -27,7 +27,9 @@ libraryDependencies ++= Seq(
   "io.circe" %% "circe-generic" % circeVersion,
   "org.scalatest" %% "scalatest" % "3.0.5" % "test",
   "org.scalamock" %% "scalamock" % "5.1.0" % "test",
-  "com.github.t3hnar" %% "scala-bcrypt" % "3.1"
+  "com.github.t3hnar" %% "scala-bcrypt" % "3.1",
+  //override jackson-databind version from aws sdk
+  "com.fasterxml.jackson.core" % "jackson-databind" % "2.15.4"
 )
 
 scalacOptions += "-Ypartial-unification"

--- a/formstack-baton-requests/localenv/start-dependencies.sh
+++ b/formstack-baton-requests/localenv/start-dependencies.sh
@@ -4,4 +4,4 @@ set -ex
 cd `dirname $0`
 
 ./stop-dependencies.sh
-docker-compose -p formstack-baton-requests up --force-recreate -d
+docker compose -p formstack-baton-requests up --force-recreate -d

--- a/formstack-baton-requests/localenv/stop-dependencies.sh
+++ b/formstack-baton-requests/localenv/stop-dependencies.sh
@@ -3,4 +3,4 @@
 set -ex
 cd `dirname $0`
 
-docker-compose -p formstack-baton-requests stop
+docker compose -p formstack-baton-requests stop


### PR DESCRIPTION
put back changes in https://github.com/guardian/identity-processes/pull/271 which had nothing to do with the build failure and replace `docker-compose` with `docker compose` to fix the github action failures
