### PR TITLE
Stop setting object acl

### DIFF
--- a/.github/workflows/ci-formstack-consents.yml
+++ b/.github/workflows/ci-formstack-consents.yml
@@ -25,12 +25,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Setup Java 11
-        uses: actions/setup-java@v3
-        with:
-          java-version: '11'
-          distribution: 'corretto'
-          cache: 'sbt'
+      - name: Setup Java and sbt
+        uses: guardian/setup-scala@v1
 
       - name: Test and build 
         run: sbt clean compile test assembly

--- a/.github/workflows/deploy-formstack.yml
+++ b/.github/workflows/deploy-formstack.yml
@@ -29,12 +29,8 @@ jobs:
         with:
           role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
           aws-region: eu-west-1
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3
-        with:
-          java-version: '11'
-          distribution: 'corretto'
-          cache: 'sbt'
+      - name: Setup Java and sbt
+        uses: guardian/setup-scala@v1
       - name: Build App
         working-directory: ${{env.DIRECTORY_NAME}}
         run: sbt clean compile assembly

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+java corretto-11.0.25.9.1

--- a/formstack-baton-requests/cloud-formation.yaml
+++ b/formstack-baton-requests/cloud-formation.yaml
@@ -241,7 +241,6 @@ Resources:
               - Effect: Allow
                 Action:
                   - s3:PutObject
-                  - s3:PutObjectAcl
                   - s3:GetObject
                 Resource: !Sub arn:aws:s3:::${ResultsBucket}/formstack-results/${Stage}/*
         - PolicyName: GetParamsPolicy
@@ -410,7 +409,6 @@ Resources:
               - Effect: Allow
                 Action:
                   - s3:PutObject
-                  - s3:PutObjectAcl
                   - s3:GetObject
                 Resource: !Sub arn:aws:s3:::${ResultsBucket}/formstack-results/${Stage}/*
         - PolicyName: GetParamsPolicy
@@ -502,7 +500,6 @@ Resources:
               - Effect: Allow
                 Action:
                   - s3:PutObject
-                  - s3:PutObjectAcl
                 Resource: !Sub arn:aws:s3:::${ResultsBucket}/formstack-results/${Stage}/*
         - PolicyName: GetParamsPolicy
           PolicyDocument:

--- a/formstack-baton-requests/src/main/scala/com/gu/identity/formstackbatonrequests/aws/S3Client.scala
+++ b/formstack-baton-requests/src/main/scala/com/gu/identity/formstackbatonrequests/aws/S3Client.scala
@@ -82,7 +82,6 @@ object S3 extends S3Client with LazyLogging {
 
   private def writeToS3(resultsBucket: String, filePath: String, contents: String): Either[Throwable, S3WriteSuccess] = Try {
     s3Client.putObject(resultsBucket, filePath, contents)
-    s3Client.setObjectAcl(resultsBucket, filePath, CannedAccessControlList.BucketOwnerRead)
   }.toEither.map(_ => S3WriteSuccess())
 
   private def formatResults(results: List[FormstackSubmissionQuestionAnswer]): String = {


### PR DESCRIPTION
### Why are you making this change?
Removing setObjectAcl to address FSBP high vulnerabilities in order to keep our AWS infrastructure secure.

### What background information is there? (e.g. an [ADR](https://github.com/guardian/ophan-data-lake/blob/master/decisions/template.md), Trello card, PR, or Issue)
https://trello.com/c/TPPHQ1Rs

### How do you know it works?
Tested in CODE.

